### PR TITLE
Implementación de resiliencia offline: Caché de sesiones con Room, fi…

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,21 +13,6 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="MainActivity2">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="MainActivity (1)">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="MainActivity (2)">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="MainActivity">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="MainActivity (3)">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,13 +1,13 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlinCompose)
+    alias(libs.plugins.ksp)
     id("com.google.gms.google-services")
     id("com.google.firebase.crashlytics")
-    id("com.google.devtools.ksp") version "2.3.4"
 }
 
 android {
-    namespace = "com.example.g45_kotlin"
+    namespace = "com.uniandes.tutorias_g45k"
     compileSdk = 36
 
     defaultConfig {
@@ -41,6 +41,7 @@ android {
 
 dependencies {
     implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
     implementation(libs.firebase.firestore)
     ksp(libs.androidx.room.compiler)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
@@ -89,5 +90,6 @@ dependencies {
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.tooling)
+    implementation("androidx.fragment:fragment-ktx:1.5.7")
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/app/src/main/java/com/example/g45_kotlin/MainActivity.kt
+++ b/app/src/main/java/com/example/g45_kotlin/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin
+package com.uniandes.tutorias_g45k
 
 import android.Manifest
 import android.content.pm.PackageManager
@@ -12,12 +12,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.core.content.ContextCompat
 import androidx.navigation.compose.rememberNavController
-import com.example.g45_kotlin.data.auth.AuthHolder
-import com.example.g45_kotlin.data.auth.AuthRepository
-import com.example.g45_kotlin.data.local.SearchHistoryManager
-import com.example.g45_kotlin.ui.theme.AppTheme
-import com.example.g45_kotlin.utilities.LightSensorManager
-import com.example.g45_kotlin.utilities.NetworkMonitor
+import com.uniandes.tutorias_g45k.data.auth.AuthHolder
+import com.uniandes.tutorias_g45k.data.auth.AuthRepository
+import com.uniandes.tutorias_g45k.data.local.SearchHistoryManager
+import com.uniandes.tutorias_g45k.ui.theme.AppTheme
+import com.uniandes.tutorias_g45k.utilities.LightSensorManager
+import com.uniandes.tutorias_g45k.utilities.NetworkMonitor
 import com.google.firebase.FirebaseApp
 
 class MainActivity : ComponentActivity() {
@@ -75,6 +75,7 @@ class MainActivity : ComponentActivity() {
     }
 
 }
+
 
 
 

--- a/app/src/main/java/com/example/g45_kotlin/MainScreen.kt
+++ b/app/src/main/java/com/example/g45_kotlin/MainScreen.kt
@@ -1,8 +1,11 @@
-package com.example.g45_kotlin
+package com.uniandes.tutorias_g45k
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,9 +13,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Home
@@ -32,6 +38,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import com.uniandes.tutorias_g45k.utilities.AnalyticsManager
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -41,33 +49,37 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import com.example.g45_kotlin.data.auth.AuthHolder
-import com.example.g45_kotlin.data.local.SearchHistoryManager
-import com.example.g45_kotlin.data.novelty.NoveltyDto
-import com.example.g45_kotlin.data.novelty.NoveltyType
-import com.example.g45_kotlin.data.user.TutorSummaryDto
-import com.example.g45_kotlin.ui.MainNoveltyViewModel
-import com.example.g45_kotlin.ui.auth.LoginScreen
-import com.example.g45_kotlin.ui.home.HomeScreen
-import com.example.g45_kotlin.ui.novelties.NoveltyScreen
-import com.example.g45_kotlin.ui.provisional_profile.ProvisionalScreen
-import com.example.g45_kotlin.ui.reservation.gateway.ReservationGateWay
-import com.example.g45_kotlin.ui.reservation.summary.ReservationSummary
-import com.example.g45_kotlin.ui.theme.AppTheme
-import com.example.g45_kotlin.ui.tutor.catalog.CatalogoContent
-import com.example.g45_kotlin.ui.tutor.catalog.TutorDetailScreen
-import com.example.g45_kotlin.ui.tutor.catalog.TutorViewModel
+import com.uniandes.tutorias_g45k.data.auth.AuthHolder
+import com.uniandes.tutorias_g45k.data.local.SearchHistoryManager
+import com.uniandes.tutorias_g45k.data.novelty.NoveltyDto
+import com.uniandes.tutorias_g45k.data.novelty.NoveltyType
+import com.uniandes.tutorias_g45k.data.user.TutorSummaryDto
+import com.uniandes.tutorias_g45k.ui.MainNoveltyViewModel
+import com.uniandes.tutorias_g45k.ui.auth.LoginScreen
+import com.uniandes.tutorias_g45k.ui.home.HomeScreen
+import com.uniandes.tutorias_g45k.ui.novelties.NoveltyScreen
+import com.uniandes.tutorias_g45k.ui.provisional_profile.ProvisionalScreen
+import com.uniandes.tutorias_g45k.ui.reservation.gateway.ReservationGateWay
+import com.uniandes.tutorias_g45k.ui.reservation.summary.ReservationSummary
+import com.uniandes.tutorias_g45k.ui.theme.AppTheme
+import com.uniandes.tutorias_g45k.ui.tutor.catalog.CatalogoContent
+import com.uniandes.tutorias_g45k.ui.tutor.catalog.TutorDetailScreen
+import com.uniandes.tutorias_g45k.ui.tutor.catalog.TutorViewModel
+import com.uniandes.tutorias_g45k.utilities.NetworkMonitor
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -102,6 +114,14 @@ fun MainScreen(modifier: Modifier = Modifier,
     val tutorsState by sharedViewModel.uiState.collectAsState()
     val searchManager= SearchHistoryManager.getInstance()
     val unReadCount by noveltyViewModel.unreadCount.collectAsState()
+    val isOnline by NetworkMonitor.isOnline.collectAsState()
+
+    // Rastreo automático de pantallas para Analytics y Crashlytics
+    LaunchedEffect(currentDestination) {
+        currentDestination?.route?.let { route ->
+            AnalyticsManager.logScreenView(route)
+        }
+    }
 
     fun onNoveltyClick (novelty: NoveltyDto){
         val entityId=novelty.entityId
@@ -122,6 +142,35 @@ fun MainScreen(modifier: Modifier = Modifier,
     }
 
     Scaffold(modifier=modifier.fillMaxSize(),
+        topBar = {
+            AnimatedVisibility(visible = !isOnline) {
+                Surface(
+                    color = Color.Black.copy(alpha = 0.7f),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .padding(vertical = 4.dp, horizontal = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.CloudOff,
+                            contentDescription = "Offline",
+                            tint = Color.White,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "Modo Offline - Datos limitados",
+                            color = Color.White,
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            }
+        },
         bottomBar = {
             AnimatedVisibility(visible = mostrarBottomBar && isLogged ){
                 NavigationBar(
@@ -300,4 +349,5 @@ fun MainScreenPreview(){
         MainScreen()
     }
 }
+
 

--- a/app/src/main/java/com/example/g45_kotlin/Routes.kt
+++ b/app/src/main/java/com/example/g45_kotlin/Routes.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin
+package com.uniandes.tutorias_g45k
 
 object Routes {
     val home="Inicio"

--- a/app/src/main/java/com/example/g45_kotlin/data/RetrofitConfig.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/RetrofitConfig.kt
@@ -1,4 +1,5 @@
-package com.example.g45_kotlin.data
+package com.uniandes.tutorias_g45k.data
 
 const val baseUrl="https://g45-backend.onrender.com"
+
 

--- a/app/src/main/java/com/example/g45_kotlin/data/auth/AuthDTOs.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/auth/AuthDTOs.kt
@@ -1,17 +1,27 @@
-package com.example.g45_kotlin.data.auth
+package com.uniandes.tutorias_g45k.data.auth
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import com.example.g45_kotlin.data.reservation.AvailabilityDto
+import com.uniandes.tutorias_g45k.data.reservation.AvailabilityDto
 
 
 @Entity(tableName = "users")
 data class UserDto(
     @PrimaryKey val uid: String,
     @ColumnInfo(name = "email") val email: String?,
-    @ColumnInfo(name="displayName")val displayName: String?,
-    @ColumnInfo(name="photoUrl") val photoUrl: String?
+    @ColumnInfo(name = "displayName") val displayName: String?,
+    @ColumnInfo(name = "photoUrl") val photoUrl: String?,
+    
+    //Campos extendidos
+    @ColumnInfo(name = "major") val major: String = "Música",
+    @ColumnInfo(name = "uniandesId") val uniandesId: String? = "23123231",
+    @ColumnInfo(name = "isTutoring") val isTutoring: Boolean = false,
+    @ColumnInfo(name = "tutoringSkills") val tutoringSkills: List<String> = emptyList(),
+    @ColumnInfo(name = "availability") val availability: AvailabilityDto = AvailabilityDto(),
+    @ColumnInfo(name = "sessionPrice") val sessionPrice: Int = 0,
+    @ColumnInfo(name = "tutorRating") val tutorRating: Double = 0.0,
+    @ColumnInfo(name = "receivedRatings") val receivedRatings: Int = 0
 )
 
 data class UserBackDto(
@@ -32,3 +42,19 @@ data class UserBackDto(
     val tutorRating: Double = 0.0,
     val receivedRatings: Int = 0,
 )
+
+fun UserBackDto.toEntity() = UserDto(
+    uid = id ?: "",
+    email = email,
+    displayName = name,
+    photoUrl = profileImageUrl,
+    major = major,
+    uniandesId = uniandesId,
+    isTutoring = isTutoring,
+    tutoringSkills = tutoringSkills,
+    availability = availability,
+    sessionPrice = sessionPrice,
+    tutorRating = tutorRating,
+    receivedRatings = receivedRatings
+)
+

--- a/app/src/main/java/com/example/g45_kotlin/data/auth/AuthDaoInterface.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/auth/AuthDaoInterface.kt
@@ -1,6 +1,8 @@
-package com.example.g45_kotlin.data.auth
+package com.uniandes.tutorias_g45k.data.auth
 
 import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 
 @Dao
@@ -11,10 +13,9 @@ interface AuthDaoInterface {
     @Query("SELECT * FROM users WHERE email = :email")
     fun getSavedUser(email: String): UserDto?
 
-    @Query("INSERT INTO users (uid, email, displayName, photoUrl) VALUES (:uid, :email, :displayName, :photoUrl)")
-    fun insert(uid: String, email: String, displayName: String, photoUrl: String)
-
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(user: UserDto): Long
 
     @Query("DELETE FROM users WHERE email = :email")
-    fun deleteSavedUser(email: String)
+    suspend fun deleteSavedUser(email: String): Int
 }

--- a/app/src/main/java/com/example/g45_kotlin/data/auth/AuthDataBase.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/auth/AuthDataBase.kt
@@ -1,13 +1,22 @@
-package com.example.g45_kotlin.data.auth
+package com.uniandes.tutorias_g45k.data.auth
 
 import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
 
-@Database(entities = [UserDto::class], version = 1)
+import com.uniandes.tutorias_g45k.data.catalog.CachedTutorEntity
+import com.uniandes.tutorias_g45k.data.catalog.TutorDao
+import com.uniandes.tutorias_g45k.data.reservation.CachedSessionEntity
+import com.uniandes.tutorias_g45k.data.reservation.SessionDao
+
+@Database(entities = [UserDto::class, CachedTutorEntity::class, CachedSessionEntity::class], version = 4, exportSchema = false)
+@TypeConverters(DataConverters::class)
 abstract class AuthDataBase : RoomDatabase() {
     abstract fun userDao(): AuthDaoInterface
+    abstract fun tutorDao(): TutorDao
+    abstract fun sessionDao(): SessionDao
 
     companion object {
         @Volatile
@@ -19,7 +28,9 @@ abstract class AuthDataBase : RoomDatabase() {
                     context.applicationContext,
                     AuthDataBase::class.java,
                     "app_database"
-                ).build()
+                )
+                    .fallbackToDestructiveMigration() // Esto evita el crash al cambiar la versión de la DB
+                    .build()
                 INSTANCE = instance
                 instance
             }

--- a/app/src/main/java/com/example/g45_kotlin/data/auth/AuthHolder.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/auth/AuthHolder.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.data.auth
+package com.uniandes.tutorias_g45k.data.auth
 
 object AuthHolder {
     lateinit var authRepo:AuthRepository

--- a/app/src/main/java/com/example/g45_kotlin/data/auth/AuthRepository.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/auth/AuthRepository.kt
@@ -1,8 +1,8 @@
-package com.example.g45_kotlin.data.auth
+package com.uniandes.tutorias_g45k.data.auth
 
 import android.content.Context
 import android.util.Log
-import com.example.g45_kotlin.data.baseUrl
+import com.uniandes.tutorias_g45k.data.baseUrl
 import com.google.android.gms.tasks.Tasks.await
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
@@ -56,13 +56,31 @@ class AuthRepository (context: Context) {
     }
 
     suspend fun saveLocalUser() {
-        val currentUser = auth.currentUser?.toDto() ?: return
-        db.userDao().insert(currentUser.uid, currentUser.email ?: "", currentUser.displayName ?: "", currentUser.photoUrl?.toString() ?: "")
+        val uid = auth.currentUser?.uid ?: return
+        try {
+            val response = apiService.getUserProfile(uid)
+            if (response.isSuccessful) {
+                response.body()?.let { userBackDto ->
+                    db.userDao().insert(userBackDto.toEntity())
+                }
+            } else {
+                // Fallback to minimal info if backend fetch fails
+                val currentUser = auth.currentUser?.toDto() ?: return
+                db.userDao().insert(currentUser)
+            }
+        } catch (e: Exception) {
+            Log.e("AuthRepository", "Error saving local user", e)
+            val currentUser = auth.currentUser?.toDto() ?: return
+            db.userDao().insert(currentUser)
+        }
     }
 
     suspend fun getLocalUser(): UserDto? {
         return db.userDao().getSavedUser(auth.currentUser?.email ?: "")
     }
+
+    fun getTutorDao() = db.tutorDao()
+    fun getSessionDao() = db.sessionDao()
 
     suspend fun deleteLocalUser(){
         db.userDao().deleteSavedUser(auth.currentUser?.email ?: "")
@@ -89,3 +107,4 @@ class AuthRepository (context: Context) {
         }
     }
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/data/auth/AuthUserApiInterface.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/auth/AuthUserApiInterface.kt
@@ -1,6 +1,7 @@
-package com.example.g45_kotlin.data.auth
+package com.uniandes.tutorias_g45k.data.auth
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -13,4 +14,8 @@ interface AuthUserApiInterface {
     suspend fun logDeviceToken(@Path("user_id") userId: String,
                                @Query("fcm_token") fcmToken: String): Response<UserBackDto>
 
+    @GET("users/{user_id}")
+    suspend fun getUserProfile(@Path("user_id") userId: String): Response<UserBackDto>
+
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/data/auth/DataConverters.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/auth/DataConverters.kt
@@ -1,0 +1,57 @@
+package com.uniandes.tutorias_g45k.data.auth
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.uniandes.tutorias_g45k.data.reservation.AvailabilityDto
+import com.uniandes.tutorias_g45k.data.reservation.ParticipantSummaryDto
+import com.uniandes.tutorias_g45k.data.reservation.SkillSummaryDto
+
+/**
+ * Estos conversores permiten que Room guarde objetos complejos (Listas, Objetos)
+ * transformándolos en JSON. Es buena idea para la persistencia de la Agenda.
+ */
+class DataConverters {
+    private val gson = Gson()
+
+    @TypeConverter
+    fun fromStringList(value: List<String>?): String {
+        return gson.toJson(value)
+    }
+
+    @TypeConverter
+    fun toStringList(value: String): List<String> {
+        val listType = object : TypeToken<List<String>>() {}.type
+        return gson.fromJson(value, listType) ?: emptyList()
+    }
+
+    @TypeConverter
+    fun fromAvailability(value: AvailabilityDto?): String {
+        return gson.toJson(value)
+    }
+
+    @TypeConverter
+    fun toAvailability(value: String): AvailabilityDto {
+        return gson.fromJson(value, AvailabilityDto::class.java) ?: AvailabilityDto()
+    }
+
+    @TypeConverter
+    fun fromParticipantSummary(value: ParticipantSummaryDto?): String {
+        return gson.toJson(value)
+    }
+
+    @TypeConverter
+    fun toParticipantSummary(value: String): ParticipantSummaryDto {
+        return gson.fromJson(value, ParticipantSummaryDto::class.java) ?: ParticipantSummaryDto(null, "", "")
+    }
+
+    @TypeConverter
+    fun fromSkillSummary(value: SkillSummaryDto?): String {
+        return gson.toJson(value)
+    }
+
+    @TypeConverter
+    fun toSkillSummary(value: String): SkillSummaryDto {
+        return gson.fromJson(value, SkillSummaryDto::class.java) ?: SkillSummaryDto(null, "")
+    }
+}

--- a/app/src/main/java/com/example/g45_kotlin/data/catalog/ApiService.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/catalog/ApiService.kt
@@ -1,7 +1,7 @@
-package com.example.g45_kotlin.data.catalog
+package com.uniandes.tutorias_g45k.data.catalog
 
-import com.example.g45_kotlin.data.reservation.SkillSummaryDto
-import com.example.g45_kotlin.data.user.TutorSummaryDto
+import com.uniandes.tutorias_g45k.data.reservation.SkillSummaryDto
+import com.uniandes.tutorias_g45k.data.user.TutorSummaryDto
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -26,3 +26,4 @@ interface ApiService {
     @GET ("skills/by-ids")
     suspend fun getTutorSkillsByIds(@Query("ids") ids: List<String>): List<SkillSummaryDto>
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/data/catalog/CachedTutorEntity.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/catalog/CachedTutorEntity.kt
@@ -1,0 +1,33 @@
+package com.uniandes.tutorias_g45k.data.catalog
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.uniandes.tutorias_g45k.data.user.TutorSummaryDto
+
+@Entity(tableName = "cached_tutors")
+data class CachedTutorEntity(
+    @PrimaryKey val id: String,
+    val name: String,
+    val major: String,
+    val rating: Double,
+    val profileImageUrl: String?,
+    val sessionPrice: Int
+)
+
+fun TutorSummaryDto.toEntity() = CachedTutorEntity(
+    id = id,
+    name = name,
+    major = major,
+    rating = rating,
+    profileImageUrl = profileImageUrl,
+    sessionPrice = sessionPrice
+)
+
+fun CachedTutorEntity.toDto() = TutorSummaryDto(
+    id = id,
+    name = name,
+    major = major,
+    rating = rating,
+    profileImageUrl = profileImageUrl,
+    sessionPrice = sessionPrice
+)

--- a/app/src/main/java/com/example/g45_kotlin/data/catalog/CatalogDTOs.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/catalog/CatalogDTOs.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.data.catalog
+package com.uniandes.tutorias_g45k.data.catalog
 
 import com.google.gson.annotations.SerializedName
 
@@ -27,4 +27,5 @@ data class ReviewResponse(
     @SerializedName("authorName") val authorName: String,
     @SerializedName("authorImageUrl") val authorImageUrl: String?
 )
+
 

--- a/app/src/main/java/com/example/g45_kotlin/data/catalog/RetrofitClient.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/catalog/RetrofitClient.kt
@@ -1,6 +1,6 @@
-package com.example.g45_kotlin.data.catalog
+package com.uniandes.tutorias_g45k.data.catalog
 
-import com.example.g45_kotlin.data.baseUrl
+import com.uniandes.tutorias_g45k.data.baseUrl
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
@@ -15,3 +15,4 @@ object RetrofitClient {
             .create(ApiService::class.java)
     }
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/data/catalog/TutorDao.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/catalog/TutorDao.kt
@@ -1,0 +1,19 @@
+package com.uniandes.tutorias_g45k.data.catalog
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.uniandes.tutorias_g45k.data.user.TutorSummaryDto
+
+@Dao
+interface TutorDao {
+    @Query("SELECT * FROM cached_tutors")
+    suspend fun getAllTutors(): List<CachedTutorEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertTutors(tutors: List<CachedTutorEntity>)
+
+    @Query("DELETE FROM cached_tutors")
+    suspend fun clearTutors()
+}

--- a/app/src/main/java/com/example/g45_kotlin/data/catalog/TutorRepository.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/catalog/TutorRepository.kt
@@ -1,10 +1,23 @@
-package com.example.g45_kotlin.data.catalog
+package com.uniandes.tutorias_g45k.data.catalog
 
-import com.example.g45_kotlin.data.user.TutorSummaryDto
+import com.uniandes.tutorias_g45k.data.user.TutorSummaryDto
+import com.uniandes.tutorias_g45k.utilities.NetworkMonitor
 
-class TutorRepository(private val apiService: ApiService = RetrofitClient.apiService) {
+class TutorRepository(
+    private val apiService: ApiService = RetrofitClient.apiService,
+    private val tutorDao: TutorDao
+) {
     
     suspend fun searchTutors(name: String? = null, major: String? = null): Result<List<TutorSummaryDto>> {
+        if (!NetworkMonitor.isOnline.value) {
+            val cached = tutorDao.getAllTutors().map { it.toDto() }
+            return if (cached.isNotEmpty()) {
+                Result.success(cached)
+            } else {
+                Result.failure(Exception("Offline y no hay datos en caché"))
+            }
+        }
+
         return try {
             val response = apiService.searchTutors(name, major)
             val tutores = response.map { res ->
@@ -17,9 +30,20 @@ class TutorRepository(private val apiService: ApiService = RetrofitClient.apiSer
                     sessionPrice = res.sessionPrice
                 )
             }
+            // Guardar en caché si es una búsqueda general (sin filtros para simplificar por ahora)
+            if (name == null && major == null) {
+                tutorDao.clearTutors()
+                tutorDao.insertTutors(tutores.map { it.toEntity() })
+            }
             Result.success(tutores)
         } catch (e: Exception) {
-            Result.failure(e)
+            // Intentar cargar de caché si falla la red
+            val cached = tutorDao.getAllTutors().map { it.toDto() }
+            if (cached.isNotEmpty()) {
+                Result.success(cached)
+            } else {
+                Result.failure(e)
+            }
         }
     }
 
@@ -54,3 +78,4 @@ class TutorRepository(private val apiService: ApiService = RetrofitClient.apiSer
     }
 
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/data/firestore/NoveltyFirestoreManage.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/firestore/NoveltyFirestoreManage.kt
@@ -1,7 +1,7 @@
-package com.example.g45_kotlin.data.firestore
+package com.uniandes.tutorias_g45k.data.firestore
 
 import android.util.Log
-import com.example.g45_kotlin.data.novelty.NoveltyDto
+import com.uniandes.tutorias_g45k.data.novelty.NoveltyDto
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query

--- a/app/src/main/java/com/example/g45_kotlin/data/firestore/ReservationsFireStoreManager.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/firestore/ReservationsFireStoreManager.kt
@@ -1,9 +1,9 @@
-package com.example.g45_kotlin.data.firestore
+package com.uniandes.tutorias_g45k.data.firestore
 
 import android.util.Log
-import com.example.g45_kotlin.data.reservation.ParticipantSummaryDto
-import com.example.g45_kotlin.data.reservation.SessionDto
-import com.example.g45_kotlin.data.reservation.SkillSummaryDto
+import com.uniandes.tutorias_g45k.data.reservation.ParticipantSummaryDto
+import com.uniandes.tutorias_g45k.data.reservation.SessionDto
+import com.uniandes.tutorias_g45k.data.reservation.SkillSummaryDto
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
@@ -85,5 +85,6 @@ class ReservationsFireStoreManager {
         }
     }
 }
+
 
 

--- a/app/src/main/java/com/example/g45_kotlin/data/local/SearchHistoryManager.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/local/SearchHistoryManager.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.data.local
+package com.uniandes.tutorias_g45k.data.local
 
 import android.content.Context
 import androidx.core.content.edit

--- a/app/src/main/java/com/example/g45_kotlin/data/novelty/NoveltyDTOs.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/novelty/NoveltyDTOs.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.data.novelty
+package com.uniandes.tutorias_g45k.data.novelty
 
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.DocumentId

--- a/app/src/main/java/com/example/g45_kotlin/data/novelty/NoveltyRepoFirestoreImp.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/novelty/NoveltyRepoFirestoreImp.kt
@@ -1,6 +1,6 @@
-package com.example.g45_kotlin.data.novelty
+package com.uniandes.tutorias_g45k.data.novelty
 
-import com.example.g45_kotlin.data.firestore.NoveltyFirestoreManage
+import com.uniandes.tutorias_g45k.data.firestore.NoveltyFirestoreManage
 import kotlinx.coroutines.flow.Flow
 
 object NoveltyRepoFirestoreImp: NoveltyRepository {

--- a/app/src/main/java/com/example/g45_kotlin/data/novelty/NoveltyRepoProvider.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/novelty/NoveltyRepoProvider.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.data.novelty
+package com.uniandes.tutorias_g45k.data.novelty
 
 object NoveltyRepoProvider {
     fun getNoveltyRepo(): NoveltyRepository {
@@ -8,3 +8,4 @@ object NoveltyRepoProvider {
         return NoveltyRepoFirestoreImp
     }
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/data/novelty/NoveltyRepository.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/novelty/NoveltyRepository.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.data.novelty
+package com.uniandes.tutorias_g45k.data.novelty
 
 import kotlinx.coroutines.flow.Flow
 

--- a/app/src/main/java/com/example/g45_kotlin/data/reservation/CachedSessionEntity.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/reservation/CachedSessionEntity.kt
@@ -1,0 +1,38 @@
+package com.uniandes.tutorias_g45k.data.reservation
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "cached_sessions")
+data class CachedSessionEntity(
+    @PrimaryKey val id: String,
+    val student: ParticipantSummaryDto,
+    val tutor: ParticipantSummaryDto,
+    val skill: SkillSummaryDto,
+    val scheduledAt: String,
+    val status: String,
+    val verifCode: String?,
+    val price: Int?
+)
+
+fun SessionDto.toEntity() = CachedSessionEntity(
+    id = id ?: "",
+    student = student,
+    tutor = tutor,
+    skill = skill,
+    scheduledAt = scheduledAt,
+    status = status,
+    verifCode = verifCode,
+    price = price
+)
+
+fun CachedSessionEntity.toDto() = SessionDto(
+    id = id,
+    student = student,
+    tutor = tutor,
+    skill = skill,
+    scheduledAt = scheduledAt,
+    status = status,
+    verifCode = verifCode,
+    price = price
+)

--- a/app/src/main/java/com/example/g45_kotlin/data/reservation/ReservationApiInterface.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/reservation/ReservationApiInterface.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.data.reservation
+package com.uniandes.tutorias_g45k.data.reservation
 
 import retrofit2.Response
 import retrofit2.http.Body
@@ -56,3 +56,4 @@ interface SessionApi {
     suspend fun getTutorSkillsByIds(@Query("ids") ids: List<String>): Response<List<SkillSummaryDto>>
 
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/data/reservation/ReservationDTOs.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/reservation/ReservationDTOs.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.data.reservation
+package com.uniandes.tutorias_g45k.data.reservation
 
 data class SessionDto(
     val id: String?=null,
@@ -43,3 +43,4 @@ data class AvailabilityDto(
     val friday: List<String> = emptyList(),
     val saturday: List<String> = emptyList()
 )
+

--- a/app/src/main/java/com/example/g45_kotlin/data/reservation/ReservationRepository.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/reservation/ReservationRepository.kt
@@ -1,13 +1,16 @@
-package com.example.g45_kotlin.data.reservation
+package com.uniandes.tutorias_g45k.data.reservation
 
 import android.util.Log
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import com.example.g45_kotlin.data.baseUrl
-import com.example.g45_kotlin.data.firestore.ReservationsFireStoreManager
+import com.uniandes.tutorias_g45k.data.baseUrl
+import com.uniandes.tutorias_g45k.data.firestore.ReservationsFireStoreManager
+import com.uniandes.tutorias_g45k.utilities.NetworkMonitor
 
-object ReservationRepository {
+class ReservationRepository(
+    private val sessionDao: SessionDao? = null
+) {
     private val apiService by lazy {Retrofit.Builder()
         .baseUrl(baseUrl)
         .addConverterFactory(GsonConverterFactory.create())
@@ -47,15 +50,37 @@ object ReservationRepository {
     }
 
     suspend fun getUpcomingUserSessions(userId: String): Result<List<SessionDto>> {
+        if (!NetworkMonitor.isOnline.value && sessionDao != null) {
+            val cached = sessionDao.getUpcomingSessions().map { it.toDto() }
+            if (cached.isNotEmpty()) {
+                return Result.success(cached)
+            }
+        }
+
         return try{
             val sessions=reservationsFireStoreManager.getUpcomingUserSessions(userId)
             Log.d("ReservationRepository", "Sessions: $sessions")
+            
+            // Update cache
+            sessionDao?.let {
+                it.clearSessions()
+                it.insertSessions(sessions.map { s -> s.toEntity() })
+            }
+            
             Result.success(sessions)
         }catch (e:Exception){
             Log.d("ReservationRepository", "Error getting sessions: ${e.message}")
+            
+            // Try cache as fallback
+            sessionDao?.let {
+                val cached = it.getUpcomingSessions().map { s -> s.toDto() }
+                if (cached.isNotEmpty()) return Result.success(cached)
+            }
+
             Result.failure(e)
         }
     }
 }
+
 
 

--- a/app/src/main/java/com/example/g45_kotlin/data/reservation/SessionDao.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/reservation/SessionDao.kt
@@ -1,0 +1,18 @@
+package com.uniandes.tutorias_g45k.data.reservation
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface SessionDao {
+    @Query("SELECT * FROM cached_sessions ORDER BY scheduledAt ASC")
+    suspend fun getUpcomingSessions(): List<CachedSessionEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSessions(sessions: List<CachedSessionEntity>)
+
+    @Query("DELETE FROM cached_sessions")
+    suspend fun clearSessions()
+}

--- a/app/src/main/java/com/example/g45_kotlin/data/user/UserApiInterface.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/user/UserApiInterface.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.data.user
+package com.uniandes.tutorias_g45k.data.user
 
 import retrofit2.Response
 import retrofit2.http.Body
@@ -12,3 +12,4 @@ interface UserApi {
     @POST("recommendations")
     suspend fun getRecommendations(@Body searchedTutors:List<String>): Response<List<TutorSummaryDto>>
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/data/user/UserDTOs.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/user/UserDTOs.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.data.user
+package com.uniandes.tutorias_g45k.data.user
 
 import com.google.gson.annotations.SerializedName
 
@@ -10,3 +10,4 @@ data class TutorSummaryDto(
     @SerializedName("profile_image_url") val profileImageUrl: String? = null,
     @SerializedName("session_price") val sessionPrice: Int
 )
+

--- a/app/src/main/java/com/example/g45_kotlin/data/user/UserRepository.kt
+++ b/app/src/main/java/com/example/g45_kotlin/data/user/UserRepository.kt
@@ -1,8 +1,8 @@
-package com.example.g45_kotlin.data.user
+package com.uniandes.tutorias_g45k.data.user
 
 import android.util.Log
-import com.example.g45_kotlin.data.baseUrl
-import com.example.g45_kotlin.data.local.SearchHistoryManager
+import com.uniandes.tutorias_g45k.data.baseUrl
+import com.uniandes.tutorias_g45k.data.local.SearchHistoryManager
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -30,3 +30,4 @@ object UserRepository {
 
     }
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/ui/LoadingDialog.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/LoadingDialog.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui
+package com.uniandes.tutorias_g45k.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -24,7 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import com.example.g45_kotlin.ui.theme.AppTheme
+import com.uniandes.tutorias_g45k.ui.theme.AppTheme
 
 @Composable
 fun LoadingDialog(
@@ -82,4 +82,5 @@ fun LoadingDialogPreview() {
         LoadingDialog(show = true)
     }
 }
+
 

--- a/app/src/main/java/com/example/g45_kotlin/ui/MainNoveltyViewModel.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/MainNoveltyViewModel.kt
@@ -1,10 +1,10 @@
-package com.example.g45_kotlin.ui
+package com.uniandes.tutorias_g45k.ui
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.g45_kotlin.data.auth.AuthHolder
-import com.example.g45_kotlin.data.novelty.NoveltyRepoProvider
+import com.uniandes.tutorias_g45k.data.auth.AuthHolder
+import com.uniandes.tutorias_g45k.data.novelty.NoveltyRepoProvider
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch

--- a/app/src/main/java/com/example/g45_kotlin/ui/NoContentOrConnectionWidget.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/NoContentOrConnectionWidget.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui
+package com.uniandes.tutorias_g45k.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -19,7 +19,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.example.g45_kotlin.R
+import com.uniandes.tutorias_g45k.R
 
 @Composable
 fun NoContentOrConnectionWidget(modifier: Modifier =Modifier, size: Int, text_style: TextStyle =MaterialTheme.typography.headlineMedium, message:String="No hay contenido disponible", missingConnection:Boolean=false){
@@ -48,4 +48,5 @@ fun NoContentOrConnectionWidgetPreview(){
     }
 
 }
+
 

--- a/app/src/main/java/com/example/g45_kotlin/ui/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/auth/LoginScreen.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.auth
+package com.uniandes.tutorias_g45k.ui.auth
 
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -36,8 +36,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.g45_kotlin.utilities.AnalyticsManager
-import com.example.g45_kotlin.utilities.GoogleAnalyticsService
+import com.uniandes.tutorias_g45k.utilities.AnalyticsManager
+import com.uniandes.tutorias_g45k.utilities.GoogleAnalyticsService
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.OAuthProvider
 
@@ -138,8 +138,18 @@ fun LoginScreen(
 
                     Spacer(modifier = Modifier.height(48.dp))
 
+                    if (state.error != null) {
+                        Text(
+                            text = state.error!!,
+                            color = MaterialTheme.colorScheme.error,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(bottom = 16.dp)
+                        )
+                    }
+
                     Button(
                         onClick = { signInWithMicrosoft() },
+                        enabled = !state.isLoading,
                         modifier = Modifier.fillMaxWidth().height(54.dp),
                         colors = ButtonDefaults.buttonColors(
                             containerColor = MaterialTheme.colorScheme.primary,
@@ -159,3 +169,4 @@ fun LoginScreen(
         }
     }
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/ui/auth/LoginState.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/auth/LoginState.kt
@@ -1,9 +1,10 @@
-package com.example.g45_kotlin.ui.auth
+package com.uniandes.tutorias_g45k.ui.auth
 
-import com.example.g45_kotlin.data.auth.UserDto
+import com.uniandes.tutorias_g45k.data.auth.UserDto
 
 data class LoginState(
     val isLoading: Boolean = false,
     val user: UserDto? = null,
     val error: String? = null
 )
+

--- a/app/src/main/java/com/example/g45_kotlin/ui/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/auth/LoginViewModel.kt
@@ -1,21 +1,33 @@
-package com.example.g45_kotlin.ui.auth
+package com.uniandes.tutorias_g45k.ui.auth
 
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.g45_kotlin.data.auth.AuthHolder
+import com.uniandes.tutorias_g45k.data.auth.AuthHolder
+import com.uniandes.tutorias_g45k.utilities.NetworkMonitor
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class LoginViewModel () : ViewModel() {
     private val _state = MutableStateFlow(LoginState())
     private val authRepository = AuthHolder.authRepo
-    val state = _state.asStateFlow()
+    val isOnline = NetworkMonitor.isOnline
+
+    val state = combine(_state, isOnline) { state, online ->
+        state.copy(error = if (!online) "No hay conexión a internet. Los datos mostrados podrían estar desactualizados." else state.error)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LoginState())
 
     fun onLoginStarted() {
+        if (!isOnline.value) {
+            _state.update { it.copy(error = "No puedes iniciar sesión sin conexión.") }
+            return
+        }
         _state.update { it.copy(isLoading = true, error = null) }
     }
 
@@ -44,3 +56,4 @@ class LoginViewModel () : ViewModel() {
         _state.update { it.copy(isLoading = false, error = message) }
     }
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/home/HomeScreen.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.home
+package com.uniandes.tutorias_g45k.ui.home
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.snapping.SnapLayoutInfoProvider
@@ -43,17 +43,22 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.g45_kotlin.data.auth.AuthHolder
-import com.example.g45_kotlin.data.user.TutorSummaryDto
-import com.example.g45_kotlin.ui.home.components.SessionBanner
-import com.example.g45_kotlin.utilities.AnalyticsManager
-import com.example.g45_kotlin.utilities.GoogleAnalyticsService
+import coil.compose.AsyncImage
+import com.uniandes.tutorias_g45k.R
+import com.uniandes.tutorias_g45k.data.auth.AuthHolder
+import com.uniandes.tutorias_g45k.data.user.TutorSummaryDto
+import com.uniandes.tutorias_g45k.ui.home.components.SessionBanner
+import com.uniandes.tutorias_g45k.utilities.AnalyticsManager
+import com.uniandes.tutorias_g45k.utilities.GoogleAnalyticsService
 
 @Composable
 fun HomeScreen(viewModel: HomeViewModel = viewModel(), onTutorClick: (TutorSummaryDto) -> Unit = {}, onMoreClick: () -> Unit = {}, onSessionClick: (String) -> Unit = {}) {
@@ -214,9 +219,16 @@ fun TutorItem(tutor: TutorSummaryDto, onSelection: () -> Unit = {}) {
             modifier = Modifier.padding(16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Surface(modifier = Modifier.size(50.dp), shape = RoundedCornerShape(25.dp), color = MaterialTheme.colorScheme.primaryContainer) {
-                Box(contentAlignment = Alignment.Center) { Text(tutor.name.take(1)) }
-            }
+            AsyncImage(
+                model = tutor.profileImageUrl,
+                contentDescription = "Foto de ${tutor.name}",
+                modifier = Modifier
+                    .size(50.dp)
+                    .clip(RoundedCornerShape(25.dp)),
+                contentScale = ContentScale.Crop,
+                placeholder = painterResource(R.drawable.profile_placeholder),
+                error = painterResource(R.drawable.profile_placeholder)
+            )
             Spacer(modifier = Modifier.width(16.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(tutor.name, fontWeight = FontWeight.Bold)
@@ -229,3 +241,4 @@ fun TutorItem(tutor: TutorSummaryDto, onSelection: () -> Unit = {}) {
         }
     }
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/ui/home/HomeState.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/home/HomeState.kt
@@ -1,7 +1,7 @@
-package com.example.g45_kotlin.ui.home
+package com.uniandes.tutorias_g45k.ui.home
 
-import com.example.g45_kotlin.data.reservation.SessionDto
-import com.example.g45_kotlin.data.user.TutorSummaryDto
+import com.uniandes.tutorias_g45k.data.reservation.SessionDto
+import com.uniandes.tutorias_g45k.data.user.TutorSummaryDto
 
 data class HomeState(
     val userName: String = "Amigo",
@@ -12,3 +12,4 @@ data class HomeState(
     val areSessionLoading: Boolean = false,
     val error: String? = null
 )
+

--- a/app/src/main/java/com/example/g45_kotlin/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/home/HomeViewModel.kt
@@ -1,10 +1,10 @@
-package com.example.g45_kotlin.ui.home
+package com.uniandes.tutorias_g45k.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.g45_kotlin.data.auth.AuthHolder
-import com.example.g45_kotlin.data.reservation.ReservationRepository
-import com.example.g45_kotlin.data.user.UserRepository
+import com.uniandes.tutorias_g45k.data.auth.AuthHolder
+import com.uniandes.tutorias_g45k.data.reservation.ReservationRepository
+import com.uniandes.tutorias_g45k.data.user.UserRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,7 +22,7 @@ class HomeViewModel : ViewModel() {
     private val authRepository = AuthHolder.authRepo
 
     private val userRepository = UserRepository
-    private val reservationRepository = ReservationRepository
+    private val reservationRepository = ReservationRepository(authRepository.getSessionDao())
 
     val state = _state.asStateFlow()
 
@@ -72,3 +72,4 @@ class HomeViewModel : ViewModel() {
         }
     }
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/ui/home/components/SessionBanner.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/home/components/SessionBanner.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.home.components
+package com.uniandes.tutorias_g45k.ui.home.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -28,11 +28,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
-import com.example.g45_kotlin.R
-import com.example.g45_kotlin.data.reservation.ParticipantSummaryDto
-import com.example.g45_kotlin.data.reservation.SessionDto
-import com.example.g45_kotlin.data.reservation.SkillSummaryDto
-import com.example.g45_kotlin.ui.theme.AppTheme
+import com.uniandes.tutorias_g45k.R
+import com.uniandes.tutorias_g45k.data.reservation.ParticipantSummaryDto
+import com.uniandes.tutorias_g45k.data.reservation.SessionDto
+import com.uniandes.tutorias_g45k.data.reservation.SkillSummaryDto
+import com.uniandes.tutorias_g45k.ui.theme.AppTheme
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -154,3 +154,4 @@ fun SessionBannerPreview(){
         )
     }
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/ui/novelties/NoveltyScreen.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/novelties/NoveltyScreen.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.novelties
+package com.uniandes.tutorias_g45k.ui.novelties
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -32,9 +32,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.g45_kotlin.data.novelty.NoveltyDto
-import com.example.g45_kotlin.ui.NoContentOrConnectionWidget
-import com.example.g45_kotlin.ui.novelties.components.NoveltyItem
+import com.uniandes.tutorias_g45k.data.novelty.NoveltyDto
+import com.uniandes.tutorias_g45k.ui.NoContentOrConnectionWidget
+import com.uniandes.tutorias_g45k.ui.novelties.components.NoveltyItem
 
 @Composable
 fun NoveltyScreen(modifier: Modifier = Modifier, viewModel: NoveltyViewModel = viewModel(), onNoveltyClick: (NoveltyDto) -> Unit = {}){

--- a/app/src/main/java/com/example/g45_kotlin/ui/novelties/NoveltyScreenState.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/novelties/NoveltyScreenState.kt
@@ -1,6 +1,6 @@
-package com.example.g45_kotlin.ui.novelties
+package com.uniandes.tutorias_g45k.ui.novelties
 
-import com.example.g45_kotlin.data.novelty.NoveltyDto
+import com.uniandes.tutorias_g45k.data.novelty.NoveltyDto
 
 data class NoveltyScreenState (
     val novelties: List<NoveltyDto> = emptyList(),

--- a/app/src/main/java/com/example/g45_kotlin/ui/novelties/NoveltyViewModel.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/novelties/NoveltyViewModel.kt
@@ -1,11 +1,11 @@
-package com.example.g45_kotlin.ui.novelties
+package com.uniandes.tutorias_g45k.ui.novelties
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.g45_kotlin.data.auth.AuthHolder
-import com.example.g45_kotlin.data.novelty.NoveltyRepoProvider
-import com.example.g45_kotlin.data.novelty.NoveltyRepository
+import com.uniandes.tutorias_g45k.data.auth.AuthHolder
+import com.uniandes.tutorias_g45k.data.novelty.NoveltyRepoProvider
+import com.uniandes.tutorias_g45k.data.novelty.NoveltyRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/example/g45_kotlin/ui/novelties/components/NoveltyItem.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/novelties/components/NoveltyItem.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.novelties.components
+package com.uniandes.tutorias_g45k.ui.novelties.components
 
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.clickable
@@ -24,9 +24,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.example.g45_kotlin.R
-import com.example.g45_kotlin.data.novelty.NoveltyDto
-import com.example.g45_kotlin.data.novelty.NoveltyType
+import com.uniandes.tutorias_g45k.R
+import com.uniandes.tutorias_g45k.data.novelty.NoveltyDto
+import com.uniandes.tutorias_g45k.data.novelty.NoveltyType
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.getValue

--- a/app/src/main/java/com/example/g45_kotlin/ui/provisional_profile/ProfileProvisionalScreen.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/provisional_profile/ProfileProvisionalScreen.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.provisional_profile
+package com.uniandes.tutorias_g45k.ui.provisional_profile
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -22,9 +22,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.g45_kotlin.ui.LoadingDialog
-import com.example.g45_kotlin.ui.theme.AppTheme
-import com.example.g45_kotlin.utilities.GoogleAnalyticsService
+import com.uniandes.tutorias_g45k.ui.LoadingDialog
+import com.uniandes.tutorias_g45k.ui.theme.AppTheme
+import com.uniandes.tutorias_g45k.utilities.GoogleAnalyticsService
 
 @Composable
 fun ProvisionalScreen(modifier: Modifier = Modifier, viewModel: ProfileViewModel = viewModel(), onReservationClick:(String)->Unit){

--- a/app/src/main/java/com/example/g45_kotlin/ui/provisional_profile/ProfileUiState.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/provisional_profile/ProfileUiState.kt
@@ -1,6 +1,6 @@
-package com.example.g45_kotlin.ui.provisional_profile
+package com.uniandes.tutorias_g45k.ui.provisional_profile
 
-import com.example.g45_kotlin.data.reservation.SessionDto
+import com.uniandes.tutorias_g45k.data.reservation.SessionDto
 
 data class ProfileUiState (
     val isLoading:Boolean=false,

--- a/app/src/main/java/com/example/g45_kotlin/ui/provisional_profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/provisional_profile/ProfileViewModel.kt
@@ -1,12 +1,12 @@
-package com.example.g45_kotlin.ui.provisional_profile
+package com.uniandes.tutorias_g45k.ui.provisional_profile
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.g45_kotlin.data.auth.AuthHolder
-import com.example.g45_kotlin.data.reservation.ReservationRepository
-import com.example.g45_kotlin.data.reservation.SessionDto
-import com.example.g45_kotlin.utilities.NetworkMonitor
+import com.uniandes.tutorias_g45k.data.auth.AuthHolder
+import com.uniandes.tutorias_g45k.data.reservation.ReservationRepository
+import com.uniandes.tutorias_g45k.data.reservation.SessionDto
+import com.uniandes.tutorias_g45k.utilities.NetworkMonitor
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,8 +16,8 @@ import kotlinx.coroutines.launch
 
 class ProfileViewModel: ViewModel() {
     private val _uiState = MutableStateFlow(ProfileUiState())
-    private val sessionRepository = ReservationRepository
     private val authRepository = AuthHolder.authRepo
+    private val sessionRepository = ReservationRepository(authRepository.getSessionDao())
 
     val uiState = _uiState.asStateFlow()
 

--- a/app/src/main/java/com/example/g45_kotlin/ui/reservation/gateway/ReservationGateWay.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/reservation/gateway/ReservationGateWay.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.reservation.gateway
+package com.uniandes.tutorias_g45k.ui.reservation.gateway
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.gestures.animateScrollBy
@@ -36,12 +36,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.g45_kotlin.ui.LoadingDialog
-import com.example.g45_kotlin.ui.reservation.gateway.components.PaymentSelection
-import com.example.g45_kotlin.ui.reservation.gateway.components.SessionSelection
-import com.example.g45_kotlin.ui.reservation.gateway.components.SkillSelector
-import com.example.g45_kotlin.ui.reservation.gateway.components.TutorBanner
-import com.example.g45_kotlin.ui.theme.AppTheme
+import com.uniandes.tutorias_g45k.ui.LoadingDialog
+import com.uniandes.tutorias_g45k.ui.reservation.gateway.components.PaymentSelection
+import com.uniandes.tutorias_g45k.ui.reservation.gateway.components.SessionSelection
+import com.uniandes.tutorias_g45k.ui.reservation.gateway.components.SkillSelector
+import com.uniandes.tutorias_g45k.ui.reservation.gateway.components.TutorBanner
+import com.uniandes.tutorias_g45k.ui.theme.AppTheme
 import kotlinx.coroutines.launch
 
 @Composable
@@ -236,3 +236,4 @@ fun ReservationGateWayPreview(){
         }
     }
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/ui/reservation/gateway/ReservationGatewayState.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/reservation/gateway/ReservationGatewayState.kt
@@ -1,6 +1,6 @@
-package com.example.g45_kotlin.ui.reservation.gateway
+package com.uniandes.tutorias_g45k.ui.reservation.gateway
 
-import com.example.g45_kotlin.data.reservation.SkillSummaryDto
+import com.uniandes.tutorias_g45k.data.reservation.SkillSummaryDto
 import java.time.LocalDate
 
 
@@ -31,4 +31,5 @@ data class TutorUser (
     val currentRating:Double = 0.0,
     val picture: String=""
 )
+
 

--- a/app/src/main/java/com/example/g45_kotlin/ui/reservation/gateway/ReservationGatewayViewModel.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/reservation/gateway/ReservationGatewayViewModel.kt
@@ -1,14 +1,14 @@
-package com.example.g45_kotlin.ui.reservation.gateway
+package com.uniandes.tutorias_g45k.ui.reservation.gateway
 import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.g45_kotlin.data.auth.AuthHolder
-import com.example.g45_kotlin.data.reservation.ParticipantSummaryDto
-import com.example.g45_kotlin.data.reservation.ReservationRepository
-import com.example.g45_kotlin.data.reservation.SessionDto
-import com.example.g45_kotlin.data.reservation.SkillSummaryDto
-import com.example.g45_kotlin.utilities.getDaysOfCurrentWeek
+import com.uniandes.tutorias_g45k.data.auth.AuthHolder
+import com.uniandes.tutorias_g45k.data.reservation.ParticipantSummaryDto
+import com.uniandes.tutorias_g45k.data.reservation.ReservationRepository
+import com.uniandes.tutorias_g45k.data.reservation.SessionDto
+import com.uniandes.tutorias_g45k.data.reservation.SkillSummaryDto
+import com.uniandes.tutorias_g45k.utilities.getDaysOfCurrentWeek
 import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,7 +31,7 @@ enum class PaymentType {
 
 
 class ReservationGatewayViewModel(savedStateHandle: SavedStateHandle):ViewModel() {
-    private val reservationRep = ReservationRepository
+    private val reservationRep = ReservationRepository(AuthHolder.authRepo.getSessionDao())
     /*TODO*/
     //Fetch from API//
     val mockPayments:List<PaymentMethod> = listOf(

--- a/app/src/main/java/com/example/g45_kotlin/ui/reservation/gateway/components/PaymentSelector.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/reservation/gateway/components/PaymentSelector.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.reservation.gateway.components
+package com.uniandes.tutorias_g45k.ui.reservation.gateway.components
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
@@ -31,10 +31,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import com.example.g45_kotlin.R
-import com.example.g45_kotlin.ui.reservation.gateway.PaymentMethod
-import com.example.g45_kotlin.ui.reservation.gateway.PaymentType
-import com.example.g45_kotlin.ui.reservation.gateway.ReservationGatewayState
+import com.uniandes.tutorias_g45k.R
+import com.uniandes.tutorias_g45k.ui.reservation.gateway.PaymentMethod
+import com.uniandes.tutorias_g45k.ui.reservation.gateway.PaymentType
+import com.uniandes.tutorias_g45k.ui.reservation.gateway.ReservationGatewayState
 
 @Composable
 fun PaymentSelection(modifier: Modifier = Modifier,

--- a/app/src/main/java/com/example/g45_kotlin/ui/reservation/gateway/components/SessionSelector.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/reservation/gateway/components/SessionSelector.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.reservation.gateway.components
+package com.uniandes.tutorias_g45k.ui.reservation.gateway.components
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
@@ -23,7 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.example.g45_kotlin.ui.reservation.gateway.ReservationGatewayState
+import com.uniandes.tutorias_g45k.ui.reservation.gateway.ReservationGatewayState
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime

--- a/app/src/main/java/com/example/g45_kotlin/ui/reservation/gateway/components/SkillSelector.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/reservation/gateway/components/SkillSelector.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.reservation.gateway.components
+package com.uniandes.tutorias_g45k.ui.reservation.gateway.components
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
@@ -17,7 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.example.g45_kotlin.data.reservation.SkillSummaryDto
+import com.uniandes.tutorias_g45k.data.reservation.SkillSummaryDto
 
 @Composable
 fun SkillSelector(modifier: Modifier =Modifier, skillsData:List<SkillSummaryDto>, onSkillSelection:(String)->Unit={}, selectedSkill:String=""){
@@ -54,4 +54,5 @@ fun SkillOption(modifier: Modifier =Modifier, skill:SkillSummaryDto, onSelection
         }
     }
 }
+
 

--- a/app/src/main/java/com/example/g45_kotlin/ui/reservation/gateway/components/TutorBanner.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/reservation/gateway/components/TutorBanner.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.reservation.gateway.components
+package com.uniandes.tutorias_g45k.ui.reservation.gateway.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -19,8 +19,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
-import com.example.g45_kotlin.R
-import com.example.g45_kotlin.ui.reservation.gateway.TutorUser
+import com.uniandes.tutorias_g45k.R
+import com.uniandes.tutorias_g45k.ui.reservation.gateway.TutorUser
 
 @Composable
 fun TutorBanner(modifier: Modifier = Modifier, tutorInfo: TutorUser){

--- a/app/src/main/java/com/example/g45_kotlin/ui/reservation/summary/ReservationSummary.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/reservation/summary/ReservationSummary.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.reservation.summary
+package com.uniandes.tutorias_g45k.ui.reservation.summary
 
 
 import android.annotation.SuppressLint
@@ -40,12 +40,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.g45_kotlin.ui.LoadingDialog
-import com.example.g45_kotlin.ui.reservation.summary.components.DetailsBanner
-import com.example.g45_kotlin.ui.reservation.summary.components.Participants
-import com.example.g45_kotlin.ui.reservation.summary.components.QrBanner
-import com.example.g45_kotlin.ui.theme.AppTheme
-import com.example.g45_kotlin.utilities.GoogleAnalyticsService
+import com.uniandes.tutorias_g45k.ui.LoadingDialog
+import com.uniandes.tutorias_g45k.ui.reservation.summary.components.DetailsBanner
+import com.uniandes.tutorias_g45k.ui.reservation.summary.components.Participants
+import com.uniandes.tutorias_g45k.ui.reservation.summary.components.QrBanner
+import com.uniandes.tutorias_g45k.ui.theme.AppTheme
+import com.uniandes.tutorias_g45k.utilities.GoogleAnalyticsService
 import java.time.LocalDateTime
 
 @Composable

--- a/app/src/main/java/com/example/g45_kotlin/ui/reservation/summary/ReservationSummaryState.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/reservation/summary/ReservationSummaryState.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.reservation.summary
+package com.uniandes.tutorias_g45k.ui.reservation.summary
 
 import java.time.LocalDateTime
 

--- a/app/src/main/java/com/example/g45_kotlin/ui/reservation/summary/ReservationSummaryViewModel.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/reservation/summary/ReservationSummaryViewModel.kt
@@ -1,11 +1,11 @@
-package com.example.g45_kotlin.ui.reservation.summary
+package com.uniandes.tutorias_g45k.ui.reservation.summary
 
 import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.g45_kotlin.data.auth.AuthHolder
-import com.example.g45_kotlin.data.reservation.ReservationRepository
+import com.uniandes.tutorias_g45k.data.auth.AuthHolder
+import com.uniandes.tutorias_g45k.data.reservation.ReservationRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,8 +18,8 @@ import java.time.OffsetDateTime
 class ReservationSummaryViewModel  (
     private val savedStateHandle: SavedStateHandle
 ):ViewModel(){
-    private val reservationRepository = ReservationRepository
     private val authRepository=AuthHolder.authRepo
+    private val reservationRepository = ReservationRepository(authRepository.getSessionDao())
 
     private val currentUserId=authRepository.getCurrentUser()?.uid
 

--- a/app/src/main/java/com/example/g45_kotlin/ui/reservation/summary/components/DetailsBanner.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/reservation/summary/components/DetailsBanner.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.reservation.summary.components
+package com.uniandes.tutorias_g45k.ui.reservation.summary.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -23,8 +23,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.example.g45_kotlin.R
-import com.example.g45_kotlin.ui.theme.AppTheme
+import com.uniandes.tutorias_g45k.R
+import com.uniandes.tutorias_g45k.ui.theme.AppTheme
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle

--- a/app/src/main/java/com/example/g45_kotlin/ui/reservation/summary/components/Participants.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/reservation/summary/components/Participants.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.reservation.summary.components
+package com.uniandes.tutorias_g45k.ui.reservation.summary.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -21,8 +21,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
-import com.example.g45_kotlin.R
-import com.example.g45_kotlin.ui.theme.AppTheme
+import com.uniandes.tutorias_g45k.R
+import com.uniandes.tutorias_g45k.ui.theme.AppTheme
 
 const val urlPlacer = "https://media.licdn.com/dms/image/v2/D4E03AQErWMZGSWwcqg/profile-displayphoto-scale_200_200/B4EZxJq0pSLAAY-/0/1770762491069?e=1773878400&v=beta&t=UABxv2St6FPX2OI3Tu_9EdEg5GkC_1PryOLmQLovLRA"
 

--- a/app/src/main/java/com/example/g45_kotlin/ui/reservation/summary/components/QrBanner.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/reservation/summary/components/QrBanner.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.reservation.summary.components
+package com.uniandes.tutorias_g45k.ui.reservation.summary.components
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.Image
@@ -27,8 +27,8 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.example.g45_kotlin.ui.theme.AppTheme
-import com.example.g45_kotlin.utilities.generateQrCodeBitmap
+import com.uniandes.tutorias_g45k.ui.theme.AppTheme
+import com.uniandes.tutorias_g45k.utilities.generateQrCodeBitmap
 import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
 
@@ -146,3 +146,4 @@ fun QrBannerPreview(modifier: Modifier = Modifier){
         QrBanner(modifier = modifier, isTutor = true, qrContent = "www.google.com", verifScan = {true})
     }
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/theme/Color.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.theme
+package com.uniandes.tutorias_g45k.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
@@ -265,3 +265,4 @@ val surfaceContainerLowDarkHighContrast = surfaceContainerLowDark
 val surfaceContainerDarkHighContrast = surfaceContainerDark
 val surfaceContainerHighDarkHighContrast = surfaceContainerHighDark
 val surfaceContainerHighestDarkHighContrast = surfaceContainerHighestDark
+

--- a/app/src/main/java/com/example/g45_kotlin/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/theme/Theme.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.theme
+package com.uniandes.tutorias_g45k.ui.theme
 import android.os.Build
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
@@ -336,6 +336,7 @@ fun AppTheme(
     )
 
 }
+
 
 
 

--- a/app/src/main/java/com/example/g45_kotlin/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/theme/Type.kt
@@ -1,11 +1,11 @@
-package com.example.g45_kotlin.ui.theme
+package com.uniandes.tutorias_g45k.ui.theme
 
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import com.example.g45_kotlin.R
+import com.uniandes.tutorias_g45k.R
 
 
 val bodyFontFamily = FontFamily(
@@ -38,4 +38,5 @@ val AppTypography = Typography(
     labelMedium = baseline.labelMedium.copy(fontFamily = bodyFontFamily),
     labelSmall = baseline.labelSmall.copy(fontFamily = bodyFontFamily),
 )
+
 

--- a/app/src/main/java/com/example/g45_kotlin/ui/tutor/catalog/TutorCatalogScreen.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/tutor/catalog/TutorCatalogScreen.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.tutor.catalog
+package com.uniandes.tutorias_g45k.ui.tutor.catalog
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -55,9 +55,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.g45_kotlin.data.user.TutorSummaryDto
-import com.example.g45_kotlin.ui.theme.AppTheme
-import com.example.g45_kotlin.utilities.GoogleAnalyticsService
+import coil.compose.AsyncImage
+import com.uniandes.tutorias_g45k.data.user.TutorSummaryDto
+import com.uniandes.tutorias_g45k.ui.theme.AppTheme
+import com.uniandes.tutorias_g45k.utilities.GoogleAnalyticsService
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -261,11 +262,13 @@ fun TutorCard(tutor: TutorSummaryDto, onClick: () -> Unit) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(verticalAlignment = Alignment.Top) {
                 Box(contentAlignment = Alignment.BottomCenter) {
-                    Box(
+                    AsyncImage(
+                        model = tutor.profileImageUrl,
+                        contentDescription = "Foto de ${tutor.name}",
                         modifier = Modifier
                             .size(80.dp)
                             .clip(RoundedCornerShape(16.dp))
-                            .background(color=MaterialTheme.colorScheme.primary)
+                            .background(color = MaterialTheme.colorScheme.primary)
                     )
                     Surface(
                         color = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/com/example/g45_kotlin/ui/tutor/catalog/TutorCatalogState.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/tutor/catalog/TutorCatalogState.kt
@@ -1,8 +1,8 @@
-package com.example.g45_kotlin.ui.tutor.catalog
+package com.uniandes.tutorias_g45k.ui.tutor.catalog
 
-import com.example.g45_kotlin.data.catalog.ReviewResponse
-import com.example.g45_kotlin.data.catalog.TutorResponse
-import com.example.g45_kotlin.data.user.TutorSummaryDto
+import com.uniandes.tutorias_g45k.data.catalog.ReviewResponse
+import com.uniandes.tutorias_g45k.data.catalog.TutorResponse
+import com.uniandes.tutorias_g45k.data.user.TutorSummaryDto
 
 data class CatalogoUiState(
     val searchText: String = "",
@@ -16,3 +16,4 @@ data class CatalogoUiState(
     val isLoading: Boolean = false,
     val error: String? = null
 )
+

--- a/app/src/main/java/com/example/g45_kotlin/ui/tutor/catalog/TutorDetailScreen.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/tutor/catalog/TutorDetailScreen.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.ui.tutor.catalog
+package com.uniandes.tutorias_g45k.ui.tutor.catalog
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -41,15 +41,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.g45_kotlin.data.catalog.ReviewResponse
-import com.example.g45_kotlin.data.catalog.TutorResponse
-import com.example.g45_kotlin.ui.theme.AppTheme
-import com.example.g45_kotlin.utilities.GoogleAnalyticsService
+import coil.compose.AsyncImage
+import com.uniandes.tutorias_g45k.R
+import com.uniandes.tutorias_g45k.data.catalog.ReviewResponse
+import com.uniandes.tutorias_g45k.data.catalog.TutorResponse
+import com.uniandes.tutorias_g45k.ui.theme.AppTheme
+import com.uniandes.tutorias_g45k.utilities.GoogleAnalyticsService
 
 @Composable
 fun TutorDetailScreen(tutor: TutorResponse, reseñas: List<ReviewResponse>, skills: List<String> = emptyList(), onBack: () -> Unit, onBook: () -> Unit ={}) {
@@ -74,6 +78,16 @@ fun TutorDetailScreen(tutor: TutorResponse, reseñas: List<ReviewResponse>, skil
                         .fillMaxWidth()
                         .height(350.dp)
                 ) {
+                    // Background/Photo
+                    AsyncImage(
+                        model = tutor.profileImageUrl,
+                        contentDescription = "Foto de ${tutor.name}",
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop,
+                        placeholder = painterResource(R.drawable.profile_placeholder),
+                        error = painterResource(R.drawable.profile_placeholder)
+                    )
+
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -83,7 +97,6 @@ fun TutorDetailScreen(tutor: TutorResponse, reseñas: List<ReviewResponse>, skil
                                     startY = 500f
                                 )
                             )
-                            .background(MaterialTheme.colorScheme.surfaceVariant)
                     )
 
                     Row(
@@ -359,3 +372,4 @@ fun DetailPreview() {
         )
     }
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/ui/tutor/catalog/TutorViewModel.kt
+++ b/app/src/main/java/com/example/g45_kotlin/ui/tutor/catalog/TutorViewModel.kt
@@ -1,11 +1,12 @@
-package com.example.g45_kotlin.ui.tutor.catalog
+package com.uniandes.tutorias_g45k.ui.tutor.catalog
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.g45_kotlin.data.catalog.ReviewResponse
-import com.example.g45_kotlin.data.catalog.TutorRepository
-import com.example.g45_kotlin.data.catalog.TutorResponse
-import com.example.g45_kotlin.data.user.TutorSummaryDto
+import com.uniandes.tutorias_g45k.data.auth.AuthHolder
+import com.uniandes.tutorias_g45k.data.catalog.ReviewResponse
+import com.uniandes.tutorias_g45k.data.catalog.TutorRepository
+import com.uniandes.tutorias_g45k.data.catalog.TutorResponse
+import com.uniandes.tutorias_g45k.data.user.TutorSummaryDto
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -13,7 +14,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class TutorViewModel(
-    private val repository: TutorRepository = TutorRepository(),
+    private val repository: TutorRepository = TutorRepository(tutorDao = AuthHolder.authRepo.getTutorDao()),
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(CatalogoUiState())
     val uiState: StateFlow<CatalogoUiState> = _uiState.asStateFlow()
@@ -136,3 +137,4 @@ class TutorViewModel(
         return isoDate.split("T").firstOrNull() ?: "Reciente"
     }
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/utilities/AnalyticsManager.kt
+++ b/app/src/main/java/com/example/g45_kotlin/utilities/AnalyticsManager.kt
@@ -1,20 +1,94 @@
-package com.example.g45_kotlin.utilities
+package com.uniandes.tutorias_g45k.utilities
 
+import android.os.Bundle
+import com.google.firebase.Firebase
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.analytics.analytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 
+/**
+ * Objeto Centralizador de Telemetría
+ * Este objeto asegura que los parámetros enviados coincidan exactamente con
+ * las Dimensiones Personalizadas configuradas en Firebase y Supabase.
+ */
 object AnalyticsManager {
-    fun setCurrentService(serviceName: String) {
-        // Esta línea es la que responde la pregunta de negocio.
-        // Si la app falla, Crashlytics nos dirá en qué "service" estaba.
-        FirebaseCrashlytics.getInstance().setCustomKey("current_service", serviceName)
+    private val analytics: FirebaseAnalytics = Firebase.analytics
+    private val crashlytics: FirebaseCrashlytics = FirebaseCrashlytics.getInstance()
+
+    // Parámetros estandarizados según requerimiento de Auditoría
+    private const val PARAM_SERVICE_NAME = "service_name"
+    private const val PARAM_REFERENCE_ID = "reference_id"
+    private const val PARAM_SCREEN_NAME = "screen_name"
+    private const val PARAM_ITEM_NAME = "item_name" // Nuevo: Para "Nombre de Botón"
+
+    /**
+     * Registra una interacción con un servicio (Materia, Tutor, etc.)
+     */
+    fun logServiceInteraction(
+        eventName: String, 
+        serviceName: String, 
+        referenceId: String, 
+        screenName: String = "unknown",
+        itemName: String? = null // Para el nombre del botón
+    ) {
+        val bundle = Bundle().apply {
+            putString(PARAM_SERVICE_NAME, serviceName)
+            putString(PARAM_REFERENCE_ID, referenceId)
+            putString(PARAM_SCREEN_NAME, screenName)
+            itemName?.let { putString(PARAM_ITEM_NAME, it) }
+        }
+        
+        analytics.logEvent(eventName, bundle)
+        
+        // Contexto para Crashlytics
+        crashlytics.setCustomKey("last_service", serviceName)
+        crashlytics.setCustomKey("last_ref_id", referenceId)
     }
 
+    /**
+     * Registra un cambio de pantalla
+     * Responde a: "¿En qué sección ocurren más errores?"
+     */
+    fun logScreenView(screenName: String, screenClass: String = "JetpackCompose") {
+        val bundle = Bundle().apply {
+            putString(FirebaseAnalytics.Param.SCREEN_NAME, screenName)
+            putString(PARAM_SCREEN_NAME, screenName) // Duplicamos para la dimensión personalizada
+            putString(FirebaseAnalytics.Param.SCREEN_CLASS, screenClass)
+        }
+        
+        analytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, bundle)
+        
+        // Sincronizamos con Crashlytics
+        crashlytics.setCustomKey("last_visible_screen", screenName)
+    }
+
+    /**
+     * Establece el servicio actual para contexto en reportes de error
+     */
+    fun setCurrentService(serviceName: String) {
+        crashlytics.setCustomKey("last_service", serviceName)
+    }
+
+    /**
+     * Establece el ID de usuario para trazabilidad entre dispositivos
+     */
+    fun setUserId(userId: String) {
+        analytics.setUserId(userId)
+        crashlytics.setUserId(userId)
+    }
+
+    /**
+     * Log de errores con contexto enriquecido
+     */
     fun logError(service: String, message: String, exception: Exception? = null) {
-        FirebaseCrashlytics.getInstance().setCustomKey("error_source", service)
+        crashlytics.setCustomKey("error_source", service)
+        crashlytics.setCustomKey("error_details", message)
+        
         if (exception != null) {
-            FirebaseCrashlytics.getInstance().recordException(exception)
+            crashlytics.recordException(exception)
         } else {
-            FirebaseCrashlytics.getInstance().log("Manual Error in $service: $message")
+            crashlytics.log("E/$service: $message")
         }
     }
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/utilities/CurrentWeekManager.kt
+++ b/app/src/main/java/com/example/g45_kotlin/utilities/CurrentWeekManager.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.utilities
+package com.uniandes.tutorias_g45k.utilities
 
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -12,5 +12,6 @@ fun getDaysOfCurrentWeek(): List<LocalDate> {
     // Entresemana mas Sabado
     return (0..5).map { monday.plusDays(it.toLong()) }
 }
+
 
 

--- a/app/src/main/java/com/example/g45_kotlin/utilities/GoogleAnalyticsService.kt
+++ b/app/src/main/java/com/example/g45_kotlin/utilities/GoogleAnalyticsService.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.utilities
+package com.uniandes.tutorias_g45k.utilities
 
 import android.util.Log
 import com.google.firebase.Firebase
@@ -8,26 +8,23 @@ import com.google.firebase.analytics.logEvent
 
 
 object GoogleAnalyticsService {
-    private val analytics= Firebase.analytics
 
     fun setUserId(userId: String) {
-        analytics.setUserId(userId)
+        AnalyticsManager.setUserId(userId)
     }
-
 
     fun logScreenAccess(screenName: String, screenClass: String = screenName) {
-        Log.d("Analytics", "Logging screen access: $screenName")
-        analytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
-            param(FirebaseAnalytics.Param.SCREEN_NAME, screenName)
-            param(FirebaseAnalytics.Param.SCREEN_CLASS, screenClass) // En Compose, solemos usar el nombre de la ruta aquí también
-        }
+        AnalyticsManager.logScreenView(screenName, screenClass)
     }
 
-    fun logButtonClick(buttonName: String, screenName: String = "unknown", buttonAction: String = "unknown") {
-        Log.d("Analytics", "Logging button click: $buttonName, in screen $screenName")
-        analytics.logEvent("button_click") {
-            param(FirebaseAnalytics.Param.ITEM_NAME, buttonName)
-            param(FirebaseAnalytics.Param.SCREEN_NAME, screenName)
-        }
+    fun logButtonClick(buttonName: String, screenName: String) {
+        AnalyticsManager.logServiceInteraction(
+            eventName = "button_click",
+            serviceName = "UI_INTERACTION",
+            referenceId = "btn_$buttonName",
+            screenName = screenName,
+            itemName = buttonName
+        )
     }
 }
+

--- a/app/src/main/java/com/example/g45_kotlin/utilities/LightSensorManager.kt
+++ b/app/src/main/java/com/example/g45_kotlin/utilities/LightSensorManager.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.utilities
+package com.uniandes.tutorias_g45k.utilities
 
 import android.content.Context
 import android.hardware.Sensor

--- a/app/src/main/java/com/example/g45_kotlin/utilities/NetworkMonitor.kt
+++ b/app/src/main/java/com/example/g45_kotlin/utilities/NetworkMonitor.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.utilities
+package com.uniandes.tutorias_g45k.utilities
 
 import android.content.Context
 import android.net.ConnectivityManager

--- a/app/src/main/java/com/example/g45_kotlin/utilities/QrManager.kt
+++ b/app/src/main/java/com/example/g45_kotlin/utilities/QrManager.kt
@@ -1,4 +1,4 @@
-package com.example.g45_kotlin.utilities
+package com.uniandes.tutorias_g45k.utilities
 import android.graphics.Bitmap
 import android.graphics.Color
 import androidx.core.graphics.createBitmap

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.compose) apply false
-    id("com.google.gms.google-services") version "4.4.4" apply false
-    id("com.google.firebase.crashlytics") version "3.0.3" apply false
-    id("com.google.devtools.ksp") version "2.3.4" apply false
+    alias(libs.plugins.kotlinAndroid) apply false
+    alias(libs.plugins.kotlinCompose) apply false
+    id("com.google.gms.google-services") version "4.4.2" apply false
+    id("com.google.firebase.crashlytics") version "3.0.2" apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,5 +21,6 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.disallowKotlinSourceSets=false
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.1.0"
+agp = "9.1.1"
 coilCompose = "2.7.0"
 converterGson = "3.0.0"
 coreKtx = "1.17.0"
@@ -10,10 +10,11 @@ junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.12.4"
-kotlin = "2.2.10"
+kotlin = "2.1.0"
+ksp = "2.1.0-1.0.29"
 composeBom = "2024.09.00"
 material3Version = "1.2.0"
-materialIconsCore = "latest_version"
+materialIconsCore = "1.7.0"
 retrofit = "3.0.0"
 uiTextGoogleFonts = "1.10.4"
 material3 = "1.4.0"
@@ -22,7 +23,7 @@ firebaseMessaging = "25.0.1"
 zxingAndroidEmbedded = "4.3.0"
 navigationCompose = "2.9.7"
 okhttp = "4.12.0"
-room = "2.6.1"
+room = "2.7.0-alpha13"
 firebaseFirestore = "26.2.0"
 
 [libraries]
@@ -70,4 +71,6 @@ firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlinCompose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
al final decidio room para facilitar lo del calendario usando TypeConverters, que deja todo en JSON de puro texto para que sea mas facil de manejar en fecha y eso, hay un archivo de DataConverters donde esta los typeConverters.

para lo del login primero intenta conectar con el backend si falla recae en firebase y de ahi toma almenos el id del usuario el correo y el nombre aunque no tenga lo demas de sesiones y eso, y para ese punto se garantiza que se haya autenticado porque si no, manda es el error de falta de internet, (me falto poner el placeholder o desactivar el boton cuando eso pasa)

tambien modifique los viewModels de las clases para verificar si hay internet o no, y en MainScreen esta la topBar donde muestra el placeholder para cuando no hay internet, tambien por ejemplo en Home para la parte de caching uso AsyncImage de la libreria Coil para que descargue las imagenes localmente.

tambien estan varios cambios que tuve que hacer por lo del analytics para que lo reconociera bien firestore porque cuando lo conectaba con mi cel para ver todos los eventos en el debugView los llamaba con not set y al final tuve que cambiar el namespace, porque habia una discrepancia entre el ID de la aplicación registrado en la consola de Firebase y el applicationId real que está enviando el dispositivo