### PR TITLE
sprint 4 reviews and pqrs historial

### DIFF
--- a/app/src/main/java/com/uniandes/tutorias_g45k/MainScreen.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/MainScreen.kt
@@ -308,6 +308,8 @@ fun MainScreen(modifier: Modifier = Modifier,
             composable(Routes.profile) {
                 ProfileScreen(modifier=Modifier.fillMaxSize(), dynamicTheme = isDynamic, onChangePreference = onChangePreference,
                     onCheckReservations = {navController.navigate(Routes.reservationList)},
+                    onCheckPQRs = {navController.navigate(Routes.pqrList)},
+                    onCheckReviews = {navController.navigate(Routes.reviewList)},
                     onSignOut = {
                     scope.launch(Dispatchers.IO) {
                         authRepository.signOut();
@@ -334,6 +336,35 @@ fun MainScreen(modifier: Modifier = Modifier,
                     Column(verticalArrangement = Arrangement.SpaceBetween,
                         horizontalAlignment = Alignment.CenterHorizontally){
                         ReservationListScreen (onReservationClick = {id->navController.navigate(Routes.reservationSummary+"/${id}")}, onBack = {navController.popBackStack()})
+                    }
+                }
+            }
+            composable(Routes.pqrList){
+                Surface(modifier=Modifier.fillMaxSize()){
+                    com.uniandes.tutorias_g45k.ui.profile.pages.pqrs.PqrListScreen(
+                        onBack = {navController.popBackStack()}
+                    )
+                }
+            }
+            composable(Routes.reviewList){
+                Surface(modifier=Modifier.fillMaxSize()){
+                    Column(verticalArrangement = Arrangement.SpaceBetween,
+                        horizontalAlignment = Alignment.CenterHorizontally){
+                        com.uniandes.tutorias_g45k.ui.profile.pages.reviews.ReviewListScreen (
+                            onReviewClick = {review->navController.navigate(Routes.reviewDetail+"/${review.id}")}, 
+                            onBack = {navController.popBackStack()}
+                        )
+                    }
+                }
+            }
+            composable(Routes.reviewDetail+"/{reviewId}") { backStackEntry ->
+                val reviewId = backStackEntry.arguments?.getString("reviewId")
+                if (reviewId != null) {
+                    Surface(modifier=Modifier.fillMaxSize()){
+                        com.uniandes.tutorias_g45k.ui.profile.pages.reviews.ReviewDetailScreen(
+                            reviewId = reviewId, 
+                            onBack = {navController.popBackStack()}
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/uniandes/tutorias_g45k/Routes.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/Routes.kt
@@ -14,6 +14,9 @@ object Routes {
     val becomeTutorSchedule="become_tutor_schedule"
     val becomeTutorPrice="become_tutor_price"
     val reservationList="reservation_list"
+    val reviewList="review_list"
+    val reviewDetail="review_detail"
+    val pqrList="pqr_list"
 
     val editPrice="edit_price"
 

--- a/app/src/main/java/com/uniandes/tutorias_g45k/data/firestore/ProfileListsFireStoreManager.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/data/firestore/ProfileListsFireStoreManager.kt
@@ -41,8 +41,10 @@ class ProfileListsFireStoreManager {
             }
 
             if (snapshot != null) {
-                // Aquí usamos toObjects para mapear automáticamente
-                val reviews = snapshot.toObjects(FirestoreReviewDto::class.java)
+                // Aquí usamos mapeo manual para asegurar que el ID del documento se asigne al DTO
+                val reviews = snapshot.documents.mapNotNull { doc ->
+                    doc.toObject(FirestoreReviewDto::class.java)?.copy(id = doc.id)
+                }
 
                 // Emitir la nueva lista al Flow
                 trySend(reviews)

--- a/app/src/main/java/com/uniandes/tutorias_g45k/data/local/ReviewLruCache.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/data/local/ReviewLruCache.kt
@@ -1,0 +1,42 @@
+package com.uniandes.tutorias_g45k.data.local
+
+import android.util.Log
+import android.util.LruCache
+import com.uniandes.tutorias_g45k.data.firestore.FirestoreReviewDto
+
+object ReviewLruCache {
+    
+    // Caché LRU que retiene las últimas 50 reseñas leídas en memoria RAM
+    // para cumplir con los requerimientos de "Caching Strategy" de forma nativa.
+    private val cache = object : LruCache<String, FirestoreReviewDto>(50) {
+        override fun entryRemoved(
+            evicted: Boolean,
+            key: String?,
+            oldValue: FirestoreReviewDto?,
+            newValue: FirestoreReviewDto?
+        ) {
+            super.entryRemoved(evicted, key, oldValue, newValue)
+            if (evicted) {
+                Log.d("LRU_CACHE", "Evicted review from RAM due to space limit: $key")
+            }
+        }
+    }
+
+    fun putReview(review: FirestoreReviewDto) {
+        val id = review.id
+        if (id.isNotEmpty()) {
+            cache.put(id, review)
+            Log.d("LRU_CACHE", "CACHE PUT: Guardada reseña $id en memoria RAM.")
+        }
+    }
+
+    fun getReview(id: String): FirestoreReviewDto? {
+        val cached = cache.get(id)
+        if (cached != null) {
+            Log.d("LRU_CACHE", "CACHE HIT: Reseña $id leída instantáneamente de RAM.")
+        } else {
+            Log.d("LRU_CACHE", "CACHE MISS: Reseña $id no encontrada en memoria RAM.")
+        }
+        return cached
+    }
+}

--- a/app/src/main/java/com/uniandes/tutorias_g45k/data/profile/ProfileRepoFirestoreImp.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/data/profile/ProfileRepoFirestoreImp.kt
@@ -30,7 +30,7 @@ object ProfileRepoFirestoreImp: ProfileRepository {
         return firestoreManager.listenToFavTutors(userId)
     }
 
-    override fun getReviews(userId: String): Flow<List<FirestoreReviewDto>> {
-        return firestoreManager.listenToReviews(userId)
+    override fun getReviews(userId: String, tutorReviews: Boolean, dayRange: Int?): Flow<List<FirestoreReviewDto>> {
+        return firestoreManager.listenToReviews(userId, tutorReviews, dayRange)
     }
 }

--- a/app/src/main/java/com/uniandes/tutorias_g45k/data/profile/ProfileRepository.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/data/profile/ProfileRepository.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface ProfileRepository {
     suspend fun getProfile(userId: String): Result<FirestoreUserSummaryDto>
-    fun getReviews(userId: String): Flow<List<FirestoreReviewDto>>
+    fun getReviews(userId: String, tutorReviews: Boolean = false, dayRange: Int? = null): Flow<List<FirestoreReviewDto>>
     fun getFavTutors(userId: String): Flow<List<FirestoreUserSummaryDto>>
     suspend fun getPQRS(userId: String): Result<List<FirestorePqrDto>>
 }

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/novelties/NoveltyViewModel.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/novelties/NoveltyViewModel.kt
@@ -40,11 +40,11 @@ class NoveltyViewModel : ViewModel() {
                     _noveltyState.update { it.copy(isLoading = true, error = null) }
                     noveltyRepo.getUnreadNovelties(currentUserId, dayRange)
                 }
-                .catch { it ->
-                    Log.e("NoveltyViewModel", "Error en stream", it)
+                .catch { error ->
+                    Log.e("NoveltyViewModel", "Error en stream", error)
                     _noveltyState.update { state ->
                         state.copy(
-                            error = "Error recuperando novedades, por favor revise su conexión a internet y refresque el listado",
+                            error = "Error recuperando novedades, por favor revise su conexion a internet y refresque el listado",
                             isLoading = false,
                             novelties = emptyList()
                         )
@@ -66,7 +66,7 @@ class NoveltyViewModel : ViewModel() {
             try {
                 noveltyRepo.markNoveltyAsRead(noveltyId)
             } catch (e: Exception) {
-                Log.e("NoveltyViewModel", "Error al descartar notificación", e)
+                Log.e("NoveltyViewModel", "Error al descartar notificacion", e)
             }
         }
     }
@@ -84,6 +84,7 @@ class NoveltyViewModel : ViewModel() {
 
     fun reLoadNovelties() {
         val current = _dayFilter.value
+        _dayFilter.value = null
         _dayFilter.value = current
     }
 }

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/novelties/components/NoveltyItem.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/novelties/components/NoveltyItem.kt
@@ -49,8 +49,8 @@ fun NoveltyItem(modifier: Modifier = Modifier, novelty: NoveltyDto, onClick: (No
     val now= Timestamp.now().toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
     val noveltyDate=novelty.createdAt.toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
     val daysDiff= ChronoUnit.DAYS.between(noveltyDate, now)
-    val hoursDiff= ChronoUnit.HOURS.between(noveltyDate, now)-daysDiff*24
-    val minutesDiff= ChronoUnit.MINUTES.between(noveltyDate, now)-hoursDiff*60
+    val hoursDiff = ChronoUnit.HOURS.between(noveltyDate, now) % 24
+    val minutesDiff = ChronoUnit.MINUTES.between(noveltyDate, now) % 60
 
     val message=when{
         daysDiff>0L -> "$daysDiff d"

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrBanner.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrBanner.kt
@@ -1,0 +1,78 @@
+package com.uniandes.tutorias_g45k.ui.profile.pages.pqrs
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.uniandes.tutorias_g45k.data.firestore.FirestorePqrDto
+import java.text.SimpleDateFormat
+import java.util.*
+
+@Composable
+fun PqrBanner(
+    modifier: Modifier = Modifier,
+    pqr: FirestorePqrDto
+) {
+    val dateFormatter = remember { SimpleDateFormat("dd MMM yyyy", Locale("es", "ES")) }
+    val formattedDate = remember(pqr.createdAt) { 
+        dateFormatter.format(pqr.createdAt.toDate()) 
+    }
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = pqr.type.uppercase(),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = pqr.status,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (pqr.status.equals("resuelto", ignoreCase = true)) 
+                                MaterialTheme.colorScheme.tertiary 
+                            else 
+                                MaterialTheme.colorScheme.error
+                )
+            }
+
+            Text(
+                text = pqr.topic,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            Text(
+                text = pqr.description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            Text(
+                text = formattedDate,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrListScreen.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrListScreen.kt
@@ -1,0 +1,122 @@
+package com.uniandes.tutorias_g45k.ui.profile.pages.pqrs
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.uniandes.tutorias_g45k.ui.NoContentOrConnectionWidget
+import com.uniandes.tutorias_g45k.utilities.GoogleAnalyticsService
+import com.uniandes.tutorias_g45k.utilities.NetworkMonitor
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PqrListScreen(
+    modifier: Modifier = Modifier,
+    viewModel: PqrListViewModel = viewModel(),
+    onBack: () -> Unit = {}
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val connected by NetworkMonitor.isOnline.collectAsState()
+
+    LaunchedEffect(Unit) {
+        GoogleAnalyticsService.logScreenAccess("PqrList")
+    }
+
+    Column(modifier = modifier.fillMaxHeight().padding(20.dp)) {
+        Spacer(modifier = Modifier.height(30.dp))
+        
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Button(
+                onClick = onBack, 
+                modifier = Modifier.requiredSize(50.dp), 
+                shape = CircleShape
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Volver",
+                    modifier = Modifier.size(25.dp)
+                )
+            }
+            Spacer(modifier = Modifier.width(16.dp))
+            Text(
+                text = "Historial PQRs",
+                style = MaterialTheme.typography.displayMedium
+            )
+        }
+        
+        Spacer(modifier = Modifier.height(20.dp))
+        
+        // EVENTUAL CONNECTIVITY BANNER
+        if (!connected) {
+            Column {
+                Text(
+                    text = "Modo Offline",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.error
+                )
+                Text(
+                    text = "No hay conexión a internet. Mostrando PQRs guardados en la caché local de Firestore.",
+                    textAlign = TextAlign.Justify,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+            Spacer(modifier = Modifier.height(20.dp))
+        }
+
+        PullToRefreshBox(
+            isRefreshing = uiState.isLoading, 
+            onRefresh = { viewModel.loadPqrs() }, 
+            modifier = Modifier.weight(1f).fillMaxWidth()
+        ) {
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                if (uiState.error.isNotBlank() && uiState.pqrs.isEmpty() && !uiState.isLoading) {
+                    item {
+                        Spacer(modifier = Modifier.height(20.dp))
+                        NoContentOrConnectionWidget(
+                            modifier = Modifier.sizeIn(150.dp, 200.dp),
+                            size = 100,
+                            message = uiState.error,
+                            text_style = MaterialTheme.typography.headlineSmall,
+                            missingConnection = !connected
+                        )
+                    }
+                } else if (uiState.pqrs.isEmpty() && !uiState.isLoading) {
+                    item {
+                        Spacer(modifier = Modifier.height(20.dp))
+                        NoContentOrConnectionWidget(
+                            modifier = Modifier.sizeIn(150.dp, 200.dp),
+                            size = 100,
+                            message = "No tienes PQRs radicados",
+                            text_style = MaterialTheme.typography.headlineSmall,
+                            missingConnection = !connected
+                        )
+                    }
+                } else {
+                    items(items = uiState.pqrs, key = { it.id }) { pqr ->
+                        PqrBanner(
+                            modifier = Modifier.fillMaxWidth(),
+                            pqr = pqr
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrListUiState.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrListUiState.kt
@@ -1,0 +1,10 @@
+package com.uniandes.tutorias_g45k.ui.profile.pages.pqrs
+
+import com.uniandes.tutorias_g45k.data.firestore.FirestorePqrDto
+
+data class PqrListUiState(
+    val isLoading: Boolean = false,
+    val pqrs: List<FirestorePqrDto> = emptyList(),
+    val error: String = "",
+    val connected: Boolean = true
+)

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrListViewModel.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrListViewModel.kt
@@ -1,0 +1,56 @@
+package com.uniandes.tutorias_g45k.ui.profile.pages.pqrs
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.uniandes.tutorias_g45k.data.auth.AuthHolder
+import com.uniandes.tutorias_g45k.data.profile.ProfileRepoProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class PqrListViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow(PqrListUiState())
+    val uiState: StateFlow<PqrListUiState> = _uiState.asStateFlow()
+
+    private val profileRepository = ProfileRepoProvider.getRepository()
+    private val authRepository = AuthHolder.authRepo
+
+    fun loadPqrs() {
+        _uiState.update { it.copy(isLoading = true, error = "") }
+        // MULTITHREADING: Operación asíncrona enviada al hilo de I/O para no bloquear el Main Thread
+        viewModelScope.launch(Dispatchers.IO) {
+            val userId = authRepository.getCurrentUser()?.uid ?: ""
+            if (userId.isBlank()) {
+                withContext(Dispatchers.Main) {
+                    _uiState.update { it.copy(isLoading = false, error = "Usuario no autenticado") }
+                }
+                return@launch
+            }
+
+            // Llamada suspendida simple en lugar de Flow, cumpliendo la filosofía de minimalismo
+            val result = profileRepository.getPQRS(userId)
+            
+            withContext(Dispatchers.Main) {
+                if (result.isSuccess) {
+                    val pqrsList = result.getOrNull() ?: emptyList()
+                    _uiState.update { it.copy(pqrs = pqrsList, isLoading = false) }
+                } else {
+                    _uiState.update { 
+                        it.copy(
+                            isLoading = false, 
+                            error = result.exceptionOrNull()?.message ?: "Error cargando PQRs"
+                        ) 
+                    }
+                }
+            }
+        }
+    }
+
+    init {
+        loadPqrs()
+    }
+}

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/reviews/ReviewBanner.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/reviews/ReviewBanner.kt
@@ -1,134 +1,90 @@
 package com.uniandes.tutorias_g45k.ui.profile.pages.reviews
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeightIn
-import androidx.compose.foundation.layout.requiredSize
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import com.uniandes.tutorias_g45k.R
-import com.uniandes.tutorias_g45k.data.reservation.ParticipantSummaryDto
-import com.uniandes.tutorias_g45k.data.reservation.SessionDto
-import com.uniandes.tutorias_g45k.data.reservation.SkillSummaryDto
-import com.uniandes.tutorias_g45k.ui.reservation.summary.Status
-import com.uniandes.tutorias_g45k.ui.theme.AppTheme
-import java.time.ZonedDateTime
-import kotlin.math.abs
+import com.uniandes.tutorias_g45k.data.firestore.FirestoreReviewDto
+import java.text.SimpleDateFormat
+import java.util.*
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SessionBanner(modifier: Modifier = Modifier,
-                  session: SessionDto,
-                  onClick: (String) -> Unit = {},
-                  currentUserId: String? = null,) {
-
-    val sessionLocalDateTime= ZonedDateTime.parse(session.scheduledAt).toLocalDateTime()
+fun ReviewBanner(
+    modifier: Modifier = Modifier,
+    review: FirestoreReviewDto,
+    onClick: (FirestoreReviewDto) -> Unit
+) {
+    // MICRO-OPTIMIZACIÓN: Usar remember para el formateador de fechas evita instanciarlo en cada recomposición (profiling point)
+    val dateFormatter = remember { SimpleDateFormat("dd MMM yyyy", Locale.forLanguageTag("es-ES")) }
+    val formattedDate = remember(review.createdAt) { 
+        dateFormatter.format(review.createdAt.toDate()) 
+    }
 
     Card(
-        modifier = modifier.requiredHeightIn(min = 150.dp, max = 200.dp).clickable(onClick = { onClick(session.id!!) }),
+        modifier = modifier.fillMaxWidth().clickable { onClick(review) },
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
     ) {
-        Surface(modifier = Modifier.padding(15.dp).fillMaxWidth(), color = MaterialTheme.colorScheme.surfaceVariant) {
-            Column(modifier=Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally){
-                Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.Start){
-                    val otherParticipant=when(currentUserId){
-                        session.student.id -> session.tutor
-                        session.tutor.id -> session.student
-                        else -> session.student
-                    }
-                    ParticipantIcon(imageUrl = otherParticipant.profileImageUrl ?: "")
-                    Spacer(modifier = Modifier.width(16.dp))
-                    Column(verticalArrangement = Arrangement.SpaceEvenly, modifier = Modifier.fillMaxWidth(fraction = 0.6f)){
-                        Text(
-                            text = "Tutoria con: ",
-                            style = MaterialTheme.typography.titleSmall
-                        )
-                        Text(
-                            text = otherParticipant.name,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            style = MaterialTheme.typography.headlineSmall
-                        )
-                        Text(
-                            text = session.skill.label,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis,
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                    }
-                    Spacer(modifier = Modifier.width(16.dp))
-                    Column(){
-                        Text(
-                            text = "${sessionLocalDateTime.dayOfMonth}/${sessionLocalDateTime.monthValue}/${sessionLocalDateTime.year}",
-                            style = MaterialTheme.typography.titleSmall
-                        )
-                        Text(
-                            text = "${if (sessionLocalDateTime.hour>12) abs(sessionLocalDateTime.hour-12) else sessionLocalDateTime.hour}:${if (sessionLocalDateTime.minute<10) "0" else ""}${sessionLocalDateTime.minute}\n${if (sessionLocalDateTime.hour>12) "PM" else "AM"}",
-                            style = MaterialTheme.typography.titleLarge
-                        )
-                    }
-                }
-                val color = if (session.status==Status.CONCLUDED.status){MaterialTheme.colorScheme.tertiary}else if (session.status==Status.PENDING.status){MaterialTheme.colorScheme.primary} else {MaterialTheme.colorScheme.error}
-                Surface(
-                    modifier = Modifier.fillMaxWidth().padding(top = 10.dp),
-                    color = color,
-                    shape = RoundedCornerShape(50.dp)
-                ){
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+            Text(
+                text = review.label,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Star,
+                        contentDescription = "Rating",
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        modifier=Modifier.padding(5.dp),
-                        textAlign = TextAlign.Center,
-                        text = session.status,
-                        style = MaterialTheme.typography.titleLarge
+                        text = review.rating.toString(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
             }
 
+            Text(
+                text = "Tutor ID: ${review.tutorId.ifBlank { "No disponible" }}",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Text(
+                text = review.details,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            Text(
+                text = formattedDate,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+            )
         }
-    }
-}
-
-@Composable
-fun ParticipantIcon(imageUrl: String){
-    AsyncImage(
-        model = imageUrl,
-        contentDescription = "UserProfilePic",
-        modifier = Modifier
-            .requiredSize(75.dp)
-            .clip(RoundedCornerShape(50.dp)),
-        contentScale = ContentScale.Crop,
-        placeholder=painterResource(R.drawable.profile_placeholder),
-        error=painterResource(R.drawable.profile_placeholder),
-        fallback=painterResource(R.drawable.profile_placeholder)
-    )
-}
-
-
-@Preview
-@Composable
-fun SessionBannerPreview(){
-    AppTheme(darkTheme = true){
-        SessionBanner(session = SessionDto(
-            student = ParticipantSummaryDto(id = "1", name = "Juan Perezuhh9huhuh", profileImageUrl = "https://media.licdn.com/dms/image/v2/D4E03AQ"), skill= SkillSummaryDto(id = "1", label = "Programaciónkknlknklnklnlnklnlnknlnknlknknl"), scheduledAt = "2026-04-14T16:00:05-05:00")
-        )
     }
 }

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/reviews/ReviewDetailScreen.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/reviews/ReviewDetailScreen.kt
@@ -1,0 +1,150 @@
+package com.uniandes.tutorias_g45k.ui.profile.pages.reviews
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.uniandes.tutorias_g45k.data.local.ReviewLruCache
+import java.text.SimpleDateFormat
+import java.util.*
+
+@Composable
+fun ReviewDetailScreen(
+    reviewId: String,
+    onBack: () -> Unit
+) {
+    // ESTRATEGIA DE CACHING: Leemos directamente del LRU Cache en memoria.
+    // Esto evita pasar objetos gigantes por el NavGraph y llamadas inútiles a Base de Datos.
+    val cachedReview = remember(reviewId) {
+        ReviewLruCache.getReview(reviewId)
+    }
+
+    val dateFormatter = remember { SimpleDateFormat("EEEE, d 'de' MMMM yyyy", Locale.forLanguageTag("es-ES")) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(20.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
+        Spacer(modifier = Modifier.height(30.dp))
+        
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            FilledIconButton(
+                onClick = onBack,
+                modifier = Modifier.requiredSize(50.dp),
+                colors = IconButtonDefaults.filledIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Volver",
+                    tint = Color.Black,
+                    modifier = Modifier.size(25.dp)
+                )
+            }
+            Spacer(modifier = Modifier.width(16.dp))
+            Text(
+                text = "Detalle de Reseña",
+                style = MaterialTheme.typography.displaySmall
+            )
+        }
+
+        Spacer(modifier = Modifier.height(30.dp))
+
+        if (cachedReview != null) {
+            val formattedDate = remember(cachedReview.createdAt) {
+                dateFormatter.format(cachedReview.createdAt.toDate())
+            }
+
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+            ) {
+                Column(modifier = Modifier.padding(20.dp)) {
+                    Text(
+                        text = cachedReview.label,
+                        style = MaterialTheme.typography.headlineMedium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "Tutor ID: ${cachedReview.tutorId.ifBlank { "No disponible" }}",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.Star,
+                            contentDescription = "Calificación",
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(24.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "${cachedReview.rating} / 5.0",
+                            style = MaterialTheme.typography.titleLarge,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                    
+                    Spacer(modifier = Modifier.height(24.dp))
+                    
+                    Text(
+                        text = "Comentarios:",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = cachedReview.details,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+
+                    Spacer(modifier = Modifier.height(30.dp))
+                    
+                    Text(
+                        text = "Escrita el $formattedDate",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    )
+                }
+            }
+        } else {
+            // CACHE MISS: Si por alguna razón el ID no existe en memoria.
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer)
+            ) {
+                Column(
+                    modifier = Modifier.padding(20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = "Reseña no encontrada en la memoria caché. Retorna a la lista para recargarla.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/reviews/ReviewListScreen.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/reviews/ReviewListScreen.kt
@@ -14,13 +14,15 @@ import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -29,28 +31,33 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.uniandes.tutorias_g45k.data.auth.AuthHolder
 import com.uniandes.tutorias_g45k.ui.NoContentOrConnectionWidget
 import com.uniandes.tutorias_g45k.utilities.GoogleAnalyticsService
 import com.uniandes.tutorias_g45k.utilities.NetworkMonitor
+import com.uniandes.tutorias_g45k.data.firestore.FirestoreReviewDto
 
 @Composable
-fun ReservationListScreen(modifier: Modifier = Modifier, viewModel: ReviewListViewModel = viewModel(), onReservationClick:(String)->Unit, onBack:()->Unit={}){
+fun ReviewListScreen(
+    modifier: Modifier = Modifier,
+    viewModel: ReviewListViewModel = viewModel(),
+    onReviewClick: (FirestoreReviewDto) -> Unit,
+    onBack: () -> Unit = {}
+) {
     val uiState by viewModel.uiState.collectAsState()
     val dayFilter by viewModel.dayFilter.collectAsState()
     val isTutor by viewModel.isTutor.collectAsState()
     val connected by NetworkMonitor.isOnline.collectAsState()
-    val ranges=setOf(1,7,15,30)
+    val ranges = listOf(7, 15, 30)
 
     val listState = rememberLazyListState()
 
-
     LaunchedEffect(Unit) {
-        GoogleAnalyticsService.logScreenAccess("ReservationList")
+        GoogleAnalyticsService.logScreenAccess("ReviewList")
     }
 
     LaunchedEffect(isTutor){
@@ -63,17 +70,24 @@ fun ReservationListScreen(modifier: Modifier = Modifier, viewModel: ReviewListVi
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Start
         ){
-            Button(onClick = {onBack()}, modifier=modifier.requiredSize(50.dp), shape= CircleShape) {
+            FilledIconButton(
+                onClick = { onBack() },
+                modifier = Modifier.requiredSize(50.dp),
+                colors = IconButtonDefaults.filledIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                )
+            ) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = "GoBack",
+                    tint = Color.Black,
                     modifier = Modifier
                         .requiredSize(25.dp)
                         .fillMaxSize()
                 )
             }
             Spacer(modifier=Modifier.width(10.dp))
-            Text(text="Reservas",
+            Text(text="Reseñas",
                 modifier=Modifier.fillMaxWidth(fraction = 0.75f),
                 style=MaterialTheme.typography.displayMedium
             )
@@ -82,12 +96,12 @@ fun ReservationListScreen(modifier: Modifier = Modifier, viewModel: ReviewListVi
         if(!connected ){
             Column(){
                 Text(
-                    text="Sin conexión",
+                    text="Modo Offline",
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.error
                 )
                 Text(
-                    text="Actualmente no tiene conexión, por lo que algunes reservas agendadas por usted u otros usuarios pueden no estar disponibles. Por favor revice y reestablezca la conexión para tener actualizadas sus sesiones.",
+                    text="Actualmente no tiene conexión. Se muestran las reseñas almacenadas localmente. Conéctese a internet para obtener las más recientes.",
                     textAlign = TextAlign.Justify,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error
@@ -100,7 +114,7 @@ fun ReservationListScreen(modifier: Modifier = Modifier, viewModel: ReviewListVi
             style = MaterialTheme.typography.titleMedium
         )
         LazyRow(modifier=Modifier, horizontalArrangement = Arrangement.spacedBy(10.dp)){
-            item{FilterButton(label = "Proximas", onClick = {viewModel.onSelectRange(0)}, selected = dayFilter==0)}
+            item{FilterButton(label = "Recientes", onClick = {viewModel.onSelectRange(1)}, selected = dayFilter==1)}
             items(ranges.size){
                 FilterButton(label = "Hace ${ranges.elementAt(it)} dia(s)", onClick = {viewModel.onSelectRange(ranges.elementAt(it))}, selected = dayFilter==ranges.elementAt(it))
             }
@@ -108,18 +122,18 @@ fun ReservationListScreen(modifier: Modifier = Modifier, viewModel: ReviewListVi
         }
         Spacer(modifier=Modifier.height(20.dp))
         Text(
-            text="Rol",
+            text="Rol (Mostrando las que has)",
             style = MaterialTheme.typography.titleMedium
         )
         Row(modifier=Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.Start){
-            FilterButton(label = "Estudiante", onClick = {viewModel.onSelectTutor(false)}, selected = !isTutor)
+            FilterButton(label = "Escrito", onClick = {viewModel.onSelectTutor(false)}, selected = !isTutor)
             Spacer(modifier=Modifier.width(10.dp))
-            FilterButton(label = "Tutor", onClick = {viewModel.onSelectTutor(true)}, selected = isTutor)
+            FilterButton(label = "Recibido", onClick = {viewModel.onSelectTutor(true)}, selected = isTutor)
         }
         Spacer(modifier=Modifier.height(20.dp))
-        PullToRefreshBox(isRefreshing = uiState.isLoading, onRefresh = {viewModel.reLoadSessions()}, modifier=Modifier.weight(1f).fillMaxWidth()) {
+        PullToRefreshBox(isRefreshing = uiState.isLoading, onRefresh = {viewModel.reLoadReviews()}, modifier=Modifier.weight(1f).fillMaxWidth()) {
             LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp), state = listState){
-                if (uiState.error!="" && uiState.sessions.isEmpty() && !uiState.isLoading){
+                if (uiState.error!="" && uiState.reviews.isEmpty() && !uiState.isLoading){
                     item {
                         Spacer(modifier = Modifier.height(20.dp))
                         NoContentOrConnectionWidget(
@@ -131,14 +145,22 @@ fun ReservationListScreen(modifier: Modifier = Modifier, viewModel: ReviewListVi
                         )
                     }
                 }else{
-                    if (uiState.sessions.isEmpty() && !uiState.isLoading){
+                    if (uiState.reviews.isEmpty() && !uiState.isLoading){
                         item{
                             Spacer(modifier=Modifier.height(20.dp))
-                            NoContentOrConnectionWidget(modifier = Modifier.sizeIn(150.dp, 200.dp), size = 100, message = "No se encontraron reservas/sesiones", text_style = MaterialTheme.typography.headlineSmall, missingConnection = !connected)
+                            NoContentOrConnectionWidget(modifier = Modifier.sizeIn(150.dp, 200.dp), size = 100, message = "No se encontraron reseñas", text_style = MaterialTheme.typography.headlineSmall, missingConnection = !connected)
                         }
                     }else{
-                        items(uiState.sessions.size){index->
-                            SessionBanner(modifier = Modifier.fillMaxWidth(), session = uiState.sessions[index], onClick = onReservationClick, currentUserId = AuthHolder.authRepo.getCurrentUser()?.uid)
+                        // MICRO-OPTIMIZACIÓN: Añadir key={ it.id } ayuda a Compose a evitar recomposiciones costosas.
+                        items(items = uiState.reviews, key = { it.id }) { review ->
+                            ReviewBanner(
+                                modifier = Modifier.fillMaxWidth(),
+                                review = review,
+                                onClick = { clickedReview -> 
+                                    com.uniandes.tutorias_g45k.data.local.ReviewLruCache.putReview(clickedReview)
+                                    onReviewClick(clickedReview)
+                                }
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/reviews/ReviewListUiState.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/reviews/ReviewListUiState.kt
@@ -1,11 +1,11 @@
 package com.uniandes.tutorias_g45k.ui.profile.pages.reviews
 
-import com.uniandes.tutorias_g45k.data.reservation.SessionDto
+import com.uniandes.tutorias_g45k.data.firestore.FirestoreReviewDto
 
 data class ReviewListUiState (
     val isLoading:Boolean=false,
-    val numSessions:Int=0,
-    val sessions: List<SessionDto> = emptyList(),
+    val numReviews:Int=0,
+    val reviews: List<FirestoreReviewDto> = emptyList(),
     val error:String="",
     val connected:Boolean=true
 )

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/reviews/ReviewListViewModel.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/reviews/ReviewListViewModel.kt
@@ -4,7 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.uniandes.tutorias_g45k.data.auth.AuthHolder
-import com.uniandes.tutorias_g45k.data.reservation.ReservationRepository
+import com.uniandes.tutorias_g45k.data.profile.ProfileRepoProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,7 +17,7 @@ import kotlinx.coroutines.launch
 
 class ReviewListViewModel: ViewModel() {
     private val _uiState = MutableStateFlow(ReviewListUiState())
-    private val sessionRepository = ReservationRepository
+    private val profileRepository = ProfileRepoProvider.getRepository()
     private val authRepository = AuthHolder.authRepo
 
     val uiState = _uiState.asStateFlow()
@@ -28,33 +28,32 @@ class ReviewListViewModel: ViewModel() {
     private val _isTutor = MutableStateFlow(false)
     val isTutor: StateFlow<Boolean> = _isTutor.asStateFlow()
 
-
-
     @OptIn(ExperimentalCoroutinesApi::class)
-    private fun listenReservations() {
-        Log.d("DEBUG_NOTI", "1. Entrando a listenReservations")
-        viewModelScope.launch {combine(_isTutor, _dayFilter){
-                    tutor, dayRange-> Pair(tutor, dayRange)
+    private fun listenReviews() {
+        Log.d("ReviewListViewModel", "1. Entrando a listenReviews")
+        viewModelScope.launch {
+            combine(_isTutor, _dayFilter) { tutor, dayRange ->
+                Pair(tutor, dayRange)
+            }
+            .flatMapLatest { (tutor, dayRange) ->
+                Log.d("ReviewListViewModel", "2. Filtro cambiado a: $dayRange")
+                _uiState.update { it.copy(isLoading = true, error = "") }
+                profileRepository.getReviews(authRepository.getCurrentUser()?.uid ?: "", tutor, dayRange)
+            }
+            .catch { it ->
+                Log.e("ReviewListViewModel", "Error en stream", it)
+                _uiState.update { state ->
+                    state.copy(
+                        error = "Error recuperando reseñas, revise su conexión a internet.",
+                        isLoading = false,
+                        reviews = emptyList()
+                    )
                 }
-                .flatMapLatest { (tutor,dayRange) ->
-                    Log.d("DEBUG_NOTI", "2. Filtro cambiado a: $dayRange")
-                    _uiState.update { it.copy(isLoading = true, error = "") }
-                    sessionRepository.getUserSessions(authRepository.getCurrentUser()?.uid ?: "", tutor, dayRange)
-                }
-                .catch { it ->
-                    Log.e("ReviewListViewModel", "Error en stream", it)
-                    _uiState.update { state ->
-                        state.copy(
-                            error = "Error recuperando sesiones, por favor revise su conexión a internet y refresque el listado",
-                            isLoading = false,
-                            sessions = emptyList()
-                        )
-                    }
-                }
-                .collect { list ->
-                    Log.d("DEBUG_NOTI", "4. DATOS RECIBIDOS: ${list.size} elementos: $list")
-                    _uiState.update { it.copy(sessions = list, isLoading = false) }
-                }
+            }
+            .collect { list ->
+                Log.d("ReviewListViewModel", "4. DATOS RECIBIDOS: ${list.size} elementos")
+                _uiState.update { it.copy(reviews = list, isLoading = false, numReviews = list.size) }
+            }
         }
     }
 
@@ -64,17 +63,19 @@ class ReviewListViewModel: ViewModel() {
 
     fun onSelectTutor(isTutor:Boolean){
         _isTutor.value=isTutor
-        reLoadSessions()
+        reLoadReviews()
     }
 
-    fun reLoadSessions() {
+    fun reLoadReviews() {
         _uiState.update { it.copy(error = "") }
         val current = _dayFilter.value
+        // Forza actualización reasignando si es necesario, aunque StateFlow descarta repeticiones
+        _dayFilter.value = null
         _dayFilter.value = current
     }
 
     init{
-        listenReservations()
+        listenReviews()
     }
 
 }


### PR DESCRIPTION
## Implementación general

En este PR terminé la parte de historial de reseñas y la implementación básica del historial de PQRs desde perfil, reutilizando la arquitectura que ya tenía el proyecto y tratando de tocar lo menos posible otras funcionalidades para evitar regresiones.

### Lo que se agregó

* Navegación desde perfil hacia:

  * listado de reseñas,
  * detalle de reseña,
  * listado de PQRs.

* La pantalla de reseñas dejó de usar la lógica placeholder basada en reservas y ahora consume datos reales desde Firestore.

* Se agregó `ReviewDetailScreen` usando navegación liviana con `reviewId` en vez de pasar DTOs completos.

* Se implementó un caché en memoria usando `LruCache` para las reseñas abiertas recientemente y evitar fetches innecesarios al abrir detalle.

* Tanto reseñas como PQRs muestran estado offline usando `NetworkMonitor` y aprovechan la persistencia local de Firestore.

---

## Cosas del Sprint 4 que cubre

### Concurrency / Multithreading

* Uso de `Dispatchers.IO` y `viewModelScope` para operaciones Firestore.
* Las reseñas se consumen usando `Flow`.

### Local storage / Eventual connectivity

* Firestore offline persistence.
* Indicadores visuales cuando no hay conexión.

### Caching

* `ReviewLruCache` usando `android.util.LruCache`.
* El detalle de reseña recupera primero desde RAM usando solo `reviewId`.

### Micro-optimization

* `key = { it.id }` en `LazyColumn`.
* Uso de `remember` para `SimpleDateFormat`.
* Navegación ligera pasando únicamente IDs.

---

## Cambios importantes

* Se corrigió el mapeo de Firestore para asignar manualmente `doc.id` al DTO de reseñas. Sin eso no funcionaban correctamente:

  * el cache,
  * la navegación al detalle,
  * ni las keys de Compose.

* Se ajustó la lógica del filtro “Recientes” porque con `0 días` Firestore no estaba incluyendo correctamente reseñas recién creadas.

* Se cambió el botón de back a `FilledIconButton` porque `Button` estaba colapsando visualmente el icono en pantallas pequeñas.

---

## Archivos principales

### Navegación

* `MainScreen.kt`
* `Routes.kt`
* `ProfileScreen.kt`

### Reviews

* `ReviewListScreen.kt`
* `ReviewBanner.kt`
* `ReviewDetailScreen.kt`
* `ReviewListViewModel.kt`
* `ReviewListUiState.kt`
* `ReviewLruCache.kt`

### PQRs

* `PqrListScreen.kt`
* `PqrBanner.kt`
* `PqrListViewModel.kt`
* `PqrListUiState.kt`

### Firestore / Repository

* `ProfileListsFireStoreManager.kt`
* `ProfileRepository.kt`
* `ProfileRepoFirestoreImp.kt`

---

## Notas

* No se agregó fetch adicional para nombres de tutor/autor porque el DTO actual solo maneja IDs y preferí no meter más complejidad ni tocar otros flujos del proyecto en este sprint.

* El detalle de reseña funciona desacoplado de Firestore usando únicamente caché en memoria.

* Antes de mergear conviene no incluir `.idea/misc.xml`.
