### PR TITLE
feat/fix: PQRs flow — image resolution, filters, theme adaptation and…

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,6 +13,9 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
+      <SelectionState runConfigName="New Run Config">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/main/java/com/uniandes/tutorias_g45k/MainScreen.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/MainScreen.kt
@@ -77,6 +77,11 @@ import com.uniandes.tutorias_g45k.ui.home.HomeScreen
 import com.uniandes.tutorias_g45k.ui.novelties.NoveltyScreen
 import com.uniandes.tutorias_g45k.ui.profile.ProfileScreen
 import com.uniandes.tutorias_g45k.ui.profile.pages.edit.TutorPriceEditScreen
+import com.uniandes.tutorias_g45k.ui.profile.pages.pqrs.PqrListScreen
+import com.uniandes.tutorias_g45k.ui.profile.pages.pqrs.PqrScreen
+import com.uniandes.tutorias_g45k.ui.profile.pages.pqrs.PqrViewModel
+import com.uniandes.tutorias_g45k.ui.profile.pages.pqrs.PqrViewModelFactory
+import com.uniandes.tutorias_g45k.ui.profile.pages.reviews.ReviewListScreen
 import com.uniandes.tutorias_g45k.ui.profile.pages.reservations.ReservationListScreen
 import com.uniandes.tutorias_g45k.ui.reservation.gateway.ReservationGateWay
 import com.uniandes.tutorias_g45k.ui.reservation.summary.ReservationSummary
@@ -310,6 +315,7 @@ fun MainScreen(modifier: Modifier = Modifier,
                     onCheckReservations = {navController.navigate(Routes.reservationList)},
                     onCheckPQRs = {navController.navigate(Routes.pqrList)},
                     onCheckReviews = {navController.navigate(Routes.reviewList)},
+                    onStartPqr = { navController.navigate(Routes.pqrs) },
                     onSignOut = {
                     scope.launch(Dispatchers.IO) {
                         authRepository.signOut();
@@ -331,6 +337,16 @@ fun MainScreen(modifier: Modifier = Modifier,
 
 
             }
+            composable(Routes.pqrList) {
+                PqrListScreen(
+                    onBack = { navController.popBackStack() },
+                    onCreatePqr = { navController.navigate(Routes.pqrs) }
+                )
+            }
+            composable(Routes.pqrs) {
+                val pqrViewModel: PqrViewModel = viewModel(factory = PqrViewModelFactory(context))
+                PqrScreen(onBack = { navController.popBackStack() }, viewModel = pqrViewModel)
+            }
             composable(Routes.reservationList){
                 Surface(modifier=Modifier.fillMaxSize()){
                     Column(verticalArrangement = Arrangement.SpaceBetween,
@@ -339,18 +355,11 @@ fun MainScreen(modifier: Modifier = Modifier,
                     }
                 }
             }
-            composable(Routes.pqrList){
-                Surface(modifier=Modifier.fillMaxSize()){
-                    com.uniandes.tutorias_g45k.ui.profile.pages.pqrs.PqrListScreen(
-                        onBack = {navController.popBackStack()}
-                    )
-                }
-            }
             composable(Routes.reviewList){
                 Surface(modifier=Modifier.fillMaxSize()){
                     Column(verticalArrangement = Arrangement.SpaceBetween,
                         horizontalAlignment = Alignment.CenterHorizontally){
-                        com.uniandes.tutorias_g45k.ui.profile.pages.reviews.ReviewListScreen (
+                        ReviewListScreen (
                             onReviewClick = {review->navController.navigate(Routes.reviewDetail+"/${review.id}")}, 
                             onBack = {navController.popBackStack()}
                         )
@@ -491,4 +500,3 @@ fun MainScreenPreview(){
         MainScreen()
     }
 }
-

--- a/app/src/main/java/com/uniandes/tutorias_g45k/Routes.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/Routes.kt
@@ -17,7 +17,6 @@ object Routes {
     val reviewList="review_list"
     val reviewDetail="review_detail"
     val pqrList="pqr_list"
-
+    val pqrs = "pqrs"
     val editPrice="edit_price"
-
 }

--- a/app/src/main/java/com/uniandes/tutorias_g45k/data/catalog/ApiService.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/data/catalog/ApiService.kt
@@ -1,5 +1,7 @@
 package com.uniandes.tutorias_g45k.data.catalog
 
+import com.uniandes.tutorias_g45k.data.profile.CreatePqrRequest
+import com.uniandes.tutorias_g45k.data.profile.PqrResponse
 import com.uniandes.tutorias_g45k.data.recommendation.TutorSummaryDto
 import com.uniandes.tutorias_g45k.data.reservation.SkillSummaryDto
 import retrofit2.http.Body
@@ -48,4 +50,7 @@ interface ApiService {
         @Path("user_id") userId: String,
         @Query("is_tutoring") isTutoring: Boolean = true
     ): Any
+
+    @POST("pqrs/")
+    suspend fun createPqr(@Body request: CreatePqrRequest): PqrResponse
 }

--- a/app/src/main/java/com/uniandes/tutorias_g45k/data/firestore/FireStoreProfileDtos.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/data/firestore/FireStoreProfileDtos.kt
@@ -16,13 +16,13 @@ data class FirestoreReviewDto (
 
 data class FirestorePqrDto (
     val id:String="",
-    val type:String="",
-    val description:String="",
-    val topic:String="",
-    val status:String="",
-    val authorId:String="",
-    val relatedIncident:String="",
-    val createdAt: Timestamp =Timestamp.now()
+    val type:String?="",
+    val description:String?="",
+    val topic:String?="",
+    val status:String?="",
+    val authorId:String?="",
+    val relatedIncident:String?="",
+    val createdAt: Timestamp? = Timestamp.now()
 )
 
 @IgnoreExtraProperties

--- a/app/src/main/java/com/uniandes/tutorias_g45k/data/firestore/ProfileListsFireStoreManager.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/data/firestore/ProfileListsFireStoreManager.kt
@@ -72,18 +72,17 @@ class ProfileListsFireStoreManager {
     }
     suspend fun getUserPqrs(userId: String, dayRange: Int? = null): List<FirestorePqrDto> {
         return try {
-            val query = db.collection("pqrs")
-                .whereEqualTo("authorId", userId)
+            var query: Query = db.collection("pqrs").whereEqualTo("authorId", userId)
             if (dayRange != null) {
                 val startOfDay = Instant.now().minus(Duration.ofDays(dayRange.toLong()))
                 val startTimeStamp = Timestamp(startOfDay.epochSecond, startOfDay.nano)
-                query.whereGreaterThanOrEqualTo("createdAt", startTimeStamp)
+                query = query.whereGreaterThanOrEqualTo("createdAt", startTimeStamp)
             }
-            query.orderBy("createdAt", Query.Direction.DESCENDING)
-            val pqrs= query.get().await().toObjects(FirestorePqrDto::class.java)
+            query = query.orderBy("createdAt", Query.Direction.DESCENDING)
+            val pqrs = query.get().await().toObjects(FirestorePqrDto::class.java)
             Log.d("ProfilePQRSFireStoreBridge", "PQRS: ${pqrs}")
             pqrs
-        }catch (e: Exception){
+        } catch (e: Exception) {
             Log.d("ProfilePQRSFireStoreBridge", "Error getting pqrs: ${e.message}")
             throw e
         }

--- a/app/src/main/java/com/uniandes/tutorias_g45k/data/local/PqrDraftManager.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/data/local/PqrDraftManager.kt
@@ -1,0 +1,55 @@
+package com.uniandes.tutorias_g45k.data.local
+
+import android.content.Context
+import androidx.core.content.edit
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+data class PqrDraft(
+    val type: String,
+    val selectedReason: String,
+    val description: String,
+    val selectedSessionId: String?
+)
+
+class PqrDraftManager(context: Context) {
+    private val prefs = context.getSharedPreferences("pqr_draft_prefs", Context.MODE_PRIVATE)
+    private val gson = Gson()
+
+    fun saveDraft(type: String, selectedReason: String, description: String, selectedSessionId: String?) {
+        val draft = PqrDraft(
+            type = type,
+            selectedReason = selectedReason,
+            description = description,
+            selectedSessionId = selectedSessionId
+        )
+        prefs.edit { putString("pqr_draft_json", gson.toJson(draft)) }
+    }
+
+    fun getDraft(): PqrDraft? {
+        val json = prefs.getString("pqr_draft_json", null) ?: return null
+        return try {
+            val type = object : TypeToken<PqrDraft>() {}.type
+            gson.fromJson(json, type)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    fun clearDraft() {
+        prefs.edit { remove("pqr_draft_json") }
+    }
+
+    companion object {
+        @Volatile
+        private var INSTANCE: PqrDraftManager? = null
+
+        fun getInstance(context: Context): PqrDraftManager {
+            return INSTANCE ?: synchronized(this) {
+                val instance = PqrDraftManager(context)
+                INSTANCE = instance
+                instance
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/uniandes/tutorias_g45k/data/profile/PqrDTOs.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/data/profile/PqrDTOs.kt
@@ -1,0 +1,23 @@
+package com.uniandes.tutorias_g45k.data.profile
+
+import com.google.gson.annotations.SerializedName
+
+data class CreatePqrRequest(
+    @SerializedName("type") val type: String,
+    @SerializedName("topic") val topic: String,
+    @SerializedName("description") val description: String,
+    @SerializedName("author_id") val authorId: String,
+    @SerializedName("related_incident") val relatedIncident: String? = null,
+    @SerializedName("status") val status: String = "Pendiente"
+)
+
+data class PqrResponse(
+    @SerializedName("id") val id: String,
+    @SerializedName("type") val type: String,
+    @SerializedName("topic") val topic: String,
+    @SerializedName("description") val description: String,
+    @SerializedName("author_id") val authorId: String,
+    @SerializedName("related_incident") val relatedIncident: String?,
+    @SerializedName("status") val status: String,
+    @SerializedName("created_at") val createdAt: String
+)

--- a/app/src/main/java/com/uniandes/tutorias_g45k/data/profile/ProfileRepoFirestoreImp.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/data/profile/ProfileRepoFirestoreImp.kt
@@ -1,5 +1,6 @@
 package com.uniandes.tutorias_g45k.data.profile
 
+import com.uniandes.tutorias_g45k.data.catalog.RetrofitClient
 import com.uniandes.tutorias_g45k.data.firestore.FirestorePqrDto
 import com.uniandes.tutorias_g45k.data.firestore.FirestoreReviewDto
 import com.uniandes.tutorias_g45k.data.firestore.FirestoreUserSummaryDto
@@ -9,6 +10,8 @@ import kotlinx.coroutines.flow.Flow
 
 object ProfileRepoFirestoreImp: ProfileRepository {
     private val firestoreManager = ProfileListsFireStoreManager()
+    private val apiService = RetrofitClient.apiService
+
     override suspend fun getProfile(userId: String): Result<FirestoreUserSummaryDto> {
         return try{
             val profile=firestoreManager.getUserDto(userId)
@@ -17,9 +20,9 @@ object ProfileRepoFirestoreImp: ProfileRepository {
             Result.failure(e)
         }
     }
-    override suspend fun getPQRS(userId: String): Result<List<FirestorePqrDto>> {
+    override suspend fun getPQRS(userId: String, dayRange: Int?): Result<List<FirestorePqrDto>> {
         return try{
-            val pqrs=firestoreManager.getUserPqrs(userId)
+            val pqrs=firestoreManager.getUserPqrs(userId, dayRange)
             Result.success(pqrs)
         }catch (e: Exception) {
             Result.failure(e)
@@ -32,5 +35,14 @@ object ProfileRepoFirestoreImp: ProfileRepository {
 
     override fun getReviews(userId: String, tutorReviews: Boolean, dayRange: Int?): Flow<List<FirestoreReviewDto>> {
         return firestoreManager.listenToReviews(userId, tutorReviews, dayRange)
+    }
+
+    override suspend fun createPqr(request: CreatePqrRequest): Result<PqrResponse> {
+        return try {
+            val response = apiService.createPqr(request)
+            Result.success(response)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 }

--- a/app/src/main/java/com/uniandes/tutorias_g45k/data/profile/ProfileRepository.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/data/profile/ProfileRepository.kt
@@ -9,5 +9,6 @@ interface ProfileRepository {
     suspend fun getProfile(userId: String): Result<FirestoreUserSummaryDto>
     fun getReviews(userId: String, tutorReviews: Boolean = false, dayRange: Int? = null): Flow<List<FirestoreReviewDto>>
     fun getFavTutors(userId: String): Flow<List<FirestoreUserSummaryDto>>
-    suspend fun getPQRS(userId: String): Result<List<FirestorePqrDto>>
+    suspend fun getPQRS(userId: String, dayRange: Int? = null): Result<List<FirestorePqrDto>>
+    suspend fun createPqr(request: CreatePqrRequest): Result<PqrResponse>
 }

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/favorites/FavoriteListScreen.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/favorites/FavoriteListScreen.kt
@@ -35,7 +35,7 @@ import com.uniandes.tutorias_g45k.utilities.GoogleAnalyticsService
 import com.uniandes.tutorias_g45k.utilities.NetworkMonitor
 
 @Composable
-fun ReservationListScreen(modifier: Modifier = Modifier, viewModel: FavoriteListViewModel = viewModel(), onReservationClick:(String)->Unit, onBack:()->Unit={}){
+fun FavoriteListScreen(modifier: Modifier = Modifier, viewModel: FavoriteListViewModel = viewModel(), onReservationClick:(String)->Unit, onBack:()->Unit={}){
     val uiState by viewModel.uiState.collectAsState()
     val connected by NetworkMonitor.isOnline.collectAsState()
 
@@ -121,4 +121,3 @@ fun FilterButton(modifier: Modifier = Modifier, label:String, onClick: () -> Uni
         )
     }
 }
-

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrListScreen.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrListScreen.kt
@@ -1,122 +1,319 @@
 package com.uniandes.tutorias_g45k.ui.profile.pages.pqrs
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.*
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+import com.uniandes.tutorias_g45k.R
 import com.uniandes.tutorias_g45k.ui.NoContentOrConnectionWidget
-import com.uniandes.tutorias_g45k.utilities.GoogleAnalyticsService
+import com.uniandes.tutorias_g45k.ui.profile.pages.reservations.FilterButton
 import com.uniandes.tutorias_g45k.utilities.NetworkMonitor
+import java.text.SimpleDateFormat
+import java.util.Locale
 
-@OptIn(ExperimentalMaterial3Api::class)
+private val dayRanges = listOf(1, 7, 15, 30)
+private val dayRangeLabels = mapOf(1 to "Hoy", 7 to "7 días", 15 to "15 días", 30 to "30 días")
+private val pqrStatuses = listOf("Pendiente", "En Revisión", "Concluida", "Cancelada")
+
 @Composable
 fun PqrListScreen(
-    modifier: Modifier = Modifier,
-    viewModel: PqrListViewModel = viewModel(),
-    onBack: () -> Unit = {}
+    onBack: () -> Unit,
+    onCreatePqr: () -> Unit,
+    viewModel: PqrListViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val connected by NetworkMonitor.isOnline.collectAsState()
+    val dayFilter by viewModel.dayFilter.collectAsState()
+    val statusFilter by viewModel.statusFilter.collectAsState()
+    val isOnline by NetworkMonitor.isOnline.collectAsState()
 
-    LaunchedEffect(Unit) {
-        GoogleAnalyticsService.logScreenAccess("PqrList")
-    }
-
-    Column(modifier = modifier.fillMaxHeight().padding(20.dp)) {
-        Spacer(modifier = Modifier.height(30.dp))
-        
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Button(
-                onClick = onBack, 
-                modifier = Modifier.requiredSize(50.dp), 
+    Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = onCreatePqr,
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
                 shape = CircleShape
             ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "Volver",
-                    modifier = Modifier.size(25.dp)
-                )
+                Icon(Icons.Default.Add, contentDescription = "Nuevo Reporte")
             }
-            Spacer(modifier = Modifier.width(16.dp))
-            Text(
-                text = "Historial PQRs",
-                style = MaterialTheme.typography.displayMedium
-            )
         }
-        
-        Spacer(modifier = Modifier.height(20.dp))
-        
-        // EVENTUAL CONNECTIVITY BANNER
-        if (!connected) {
-            Column {
-                Text(
-                    text = "Modo Offline",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.error
-                )
-                Text(
-                    text = "No hay conexión a internet. Mostrando PQRs guardados en la caché local de Firestore.",
-                    textAlign = TextAlign.Justify,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error
-                )
-            }
-            Spacer(modifier = Modifier.height(20.dp))
-        }
-
-        PullToRefreshBox(
-            isRefreshing = uiState.isLoading, 
-            onRefresh = { viewModel.loadPqrs() }, 
-            modifier = Modifier.weight(1f).fillMaxWidth()
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxHeight()
+                .padding(20.dp)
         ) {
-            LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                if (uiState.error.isNotBlank() && uiState.pqrs.isEmpty() && !uiState.isLoading) {
-                    item {
-                        Spacer(modifier = Modifier.height(20.dp))
-                        NoContentOrConnectionWidget(
-                            modifier = Modifier.sizeIn(150.dp, 200.dp),
-                            size = 100,
-                            message = uiState.error,
-                            text_style = MaterialTheme.typography.headlineSmall,
-                            missingConnection = !connected
-                        )
-                    }
-                } else if (uiState.pqrs.isEmpty() && !uiState.isLoading) {
-                    item {
-                        Spacer(modifier = Modifier.height(20.dp))
-                        NoContentOrConnectionWidget(
-                            modifier = Modifier.sizeIn(150.dp, 200.dp),
-                            size = 100,
-                            message = "No tienes PQRs radicados",
-                            text_style = MaterialTheme.typography.headlineSmall,
-                            missingConnection = !connected
-                        )
-                    }
-                } else {
-                    items(items = uiState.pqrs, key = { it.id }) { pqr ->
-                        PqrBanner(
-                            modifier = Modifier.fillMaxWidth(),
-                            pqr = pqr
-                        )
+            Spacer(modifier = Modifier.height(30.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Start
+            ) {
+                Button(
+                    onClick = onBack,
+                    modifier = Modifier.requiredSize(50.dp),
+                    shape = CircleShape
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Volver",
+                        modifier = Modifier.requiredSize(25.dp).fillMaxSize()
+                    )
+                }
+                Spacer(modifier = Modifier.width(10.dp))
+                Text(
+                    text = "Reportes",
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.displayMedium,
+                    maxLines = 1
+                )
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            if (!isOnline) {
+                Column {
+                    Text(
+                        text = "Sin conexión",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                    Text(
+                        text = "No hay conexión a internet. Mostrando PQRs guardados en caché local.",
+                        textAlign = TextAlign.Justify,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+                Spacer(modifier = Modifier.height(20.dp))
+            }
+
+            Text(text = "Temporalidad", style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(8.dp))
+            LazyRow(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                item {
+                    FilterButton(
+                        label = "Todas",
+                        onClick = { viewModel.onSelectDayRange(null) },
+                        selected = dayFilter == null
+                    )
+                }
+                items(dayRanges) { range ->
+                    FilterButton(
+                        label = dayRangeLabels[range] ?: "$range días",
+                        onClick = { viewModel.onSelectDayRange(range) },
+                        selected = dayFilter == range
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(text = "Estado", style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(8.dp))
+            LazyRow(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                item {
+                    FilterButton(
+                        label = "Todos",
+                        onClick = { viewModel.onSelectStatus(null) },
+                        selected = statusFilter == null
+                    )
+                }
+                items(pqrStatuses) { status ->
+                    FilterButton(
+                        label = status,
+                        onClick = { viewModel.onSelectStatus(status) },
+                        selected = statusFilter == status
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            PullToRefreshBox(
+                isRefreshing = uiState.isLoading,
+                onRefresh = { viewModel.fetchPqrs() },
+                modifier = Modifier.weight(1f).fillMaxWidth()
+            ) {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    if (uiState.error != null && uiState.displayItems.isEmpty() && !uiState.isLoading) {
+                        item {
+                            Spacer(modifier = Modifier.height(20.dp))
+                            NoContentOrConnectionWidget(
+                                modifier = Modifier.sizeIn(150.dp, 200.dp),
+                                size = 100,
+                                message = uiState.error!!,
+                                text_style = MaterialTheme.typography.headlineSmall,
+                                missingConnection = !isOnline
+                            )
+                        }
+                    } else if (uiState.displayItems.isEmpty() && !uiState.isLoading) {
+                        item {
+                            Spacer(modifier = Modifier.height(20.dp))
+                            NoContentOrConnectionWidget(
+                                modifier = Modifier.sizeIn(150.dp, 200.dp),
+                                size = 100,
+                                message = "No se encontraron reportes",
+                                text_style = MaterialTheme.typography.headlineSmall,
+                                missingConnection = !isOnline
+                            )
+                        }
+                    } else {
+                        items(uiState.displayItems) { item ->
+                            PqrItem(modifier = Modifier.fillMaxWidth(), item = item)
+                        }
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+fun PqrItem(modifier: Modifier = Modifier, item: PqrDisplayItem) {
+    val pqr = item.pqr
+    val sdf = SimpleDateFormat("dd MMM yyyy", Locale.getDefault())
+    val dateStr = pqr.createdAt?.let { sdf.format(it.toDate()) } ?: "Fecha desconocida"
+
+    Surface(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(16.dp),
+        tonalElevation = 2.dp
+    ) {
+        Row(modifier = Modifier.padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
+            if (!item.imageUrl.isNullOrBlank()) {
+                AsyncImage(
+                    model = item.imageUrl,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(CircleShape),
+                    contentScale = ContentScale.Crop,
+                    error = painterResource(R.drawable.profile_placeholder),
+                    fallback = painterResource(R.drawable.profile_placeholder)
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .background(MaterialTheme.colorScheme.primaryContainer, CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = pqr.topic?.take(1)?.uppercase() ?: "?",
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = pqr.topic?.ifBlank { "Sin Asunto" } ?: "Sin Asunto",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.weight(1f)
+                    )
+                    PqrStatusChip(status = pqr.status ?: "Pendiente")
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = pqr.description ?: "Sin descripción",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = pqr.type ?: "N/A",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                    Text(
+                        text = dateStr,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun PqrStatusChip(status: String) {
+    val (containerColor, contentColor) = when (status.lowercase()) {
+        "pendiente"    -> MaterialTheme.colorScheme.tertiaryContainer to MaterialTheme.colorScheme.onTertiaryContainer
+        "en revisión"  -> MaterialTheme.colorScheme.secondaryContainer to MaterialTheme.colorScheme.onSecondaryContainer
+        "concluida"    -> MaterialTheme.colorScheme.primaryContainer to MaterialTheme.colorScheme.onPrimaryContainer
+        else           -> MaterialTheme.colorScheme.errorContainer to MaterialTheme.colorScheme.onErrorContainer
+    }
+    Surface(
+        color = containerColor,
+        shape = RoundedCornerShape(8.dp)
+    ) {
+        Text(
+            text = status,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color = contentColor,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+        )
     }
 }

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrListUiState.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrListUiState.kt
@@ -2,9 +2,13 @@ package com.uniandes.tutorias_g45k.ui.profile.pages.pqrs
 
 import com.uniandes.tutorias_g45k.data.firestore.FirestorePqrDto
 
+data class PqrDisplayItem(
+    val pqr: FirestorePqrDto,
+    val imageUrl: String?
+)
+
 data class PqrListUiState(
+    val displayItems: List<PqrDisplayItem> = emptyList(),
     val isLoading: Boolean = false,
-    val pqrs: List<FirestorePqrDto> = emptyList(),
-    val error: String = "",
-    val connected: Boolean = true
+    val error: String? = null
 )

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrListViewModel.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrListViewModel.kt
@@ -3,54 +3,77 @@ package com.uniandes.tutorias_g45k.ui.profile.pages.pqrs
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.uniandes.tutorias_g45k.data.auth.AuthHolder
-import com.uniandes.tutorias_g45k.data.profile.ProfileRepoProvider
-import kotlinx.coroutines.Dispatchers
+import com.uniandes.tutorias_g45k.data.profile.ProfileRepoFirestoreImp
+import com.uniandes.tutorias_g45k.data.profile.ProfileRepository
+import com.uniandes.tutorias_g45k.data.reservation.ReservationRepository
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
-class PqrListViewModel : ViewModel() {
+class PqrListViewModel(
+    private val profileRepository: ProfileRepository = ProfileRepoFirestoreImp,
+    private val reservationRepository: ReservationRepository = ReservationRepository
+) : ViewModel() {
+
     private val _uiState = MutableStateFlow(PqrListUiState())
     val uiState: StateFlow<PqrListUiState> = _uiState.asStateFlow()
 
-    private val profileRepository = ProfileRepoProvider.getRepository()
-    private val authRepository = AuthHolder.authRepo
+    private val _dayFilter = MutableStateFlow<Int?>(null)
+    val dayFilter: StateFlow<Int?> = _dayFilter.asStateFlow()
 
-    fun loadPqrs() {
-        _uiState.update { it.copy(isLoading = true, error = "") }
-        // MULTITHREADING: Operación asíncrona enviada al hilo de I/O para no bloquear el Main Thread
-        viewModelScope.launch(Dispatchers.IO) {
-            val userId = authRepository.getCurrentUser()?.uid ?: ""
-            if (userId.isBlank()) {
-                withContext(Dispatchers.Main) {
-                    _uiState.update { it.copy(isLoading = false, error = "Usuario no autenticado") }
-                }
-                return@launch
-            }
+    private val _statusFilter = MutableStateFlow<String?>(null)
+    val statusFilter: StateFlow<String?> = _statusFilter.asStateFlow()
 
-            // Llamada suspendida simple en lugar de Flow, cumpliendo la filosofía de minimalismo
-            val result = profileRepository.getPQRS(userId)
-            
-            withContext(Dispatchers.Main) {
-                if (result.isSuccess) {
-                    val pqrsList = result.getOrNull() ?: emptyList()
-                    _uiState.update { it.copy(pqrs = pqrsList, isLoading = false) }
-                } else {
-                    _uiState.update { 
-                        it.copy(
-                            isLoading = false, 
-                            error = result.exceptionOrNull()?.message ?: "Error cargando PQRs"
-                        ) 
-                    }
+    init {
+        fetchPqrs()
+    }
+
+    fun fetchPqrs() {
+        val userId = AuthHolder.authRepo.getCurrentUserId() ?: return
+        val dayRange = _dayFilter.value
+        val status = _statusFilter.value
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            profileRepository.getPQRS(userId, dayRange)
+                .onSuccess { pqrs ->
+                    val filtered = if (status != null) pqrs.filter { it.status == status } else pqrs
+                    val displayItems = filtered.map { pqr ->
+                        async {
+                            val incidentId = pqr.relatedIncident
+                            val imageUrl = if (!incidentId.isNullOrBlank()) {
+                                reservationRepository.getSession(incidentId)
+                                    .getOrNull()
+                                    ?.let { session ->
+                                        if (session.student.id == userId) session.tutor.profileImageUrl
+                                        else session.student.profileImageUrl
+                                    }
+                            } else {
+                                pqr.authorId?.takeIf { it.isNotBlank() }?.let { authorId ->
+                                    profileRepository.getProfile(authorId).getOrNull()?.profileImageUrl
+                                }
+                            }
+                            PqrDisplayItem(pqr = pqr, imageUrl = imageUrl)
+                        }
+                    }.awaitAll()
+                    _uiState.update { it.copy(displayItems = displayItems, isLoading = false, error = null) }
                 }
-            }
+                .onFailure { error ->
+                    _uiState.update { it.copy(error = error.message, isLoading = false) }
+                }
         }
     }
 
-    init {
-        loadPqrs()
+    fun onSelectDayRange(range: Int?) {
+        _dayFilter.value = range
+        fetchPqrs()
+    }
+
+    fun onSelectStatus(status: String?) {
+        _statusFilter.value = status
+        fetchPqrs()
     }
 }

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrScreen.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrScreen.kt
@@ -1,0 +1,374 @@
+package com.uniandes.tutorias_g45k.ui.profile.pages.pqrs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.RadioButtonChecked
+import androidx.compose.material.icons.filled.RadioButtonUnchecked
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import coil.compose.AsyncImage
+import com.uniandes.tutorias_g45k.R
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.uniandes.tutorias_g45k.data.reservation.SessionDto
+import com.uniandes.tutorias_g45k.utilities.NetworkMonitor
+
+@Composable
+fun PqrScreen(
+    onBack: () -> Unit,
+    viewModel: PqrViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val isOnline by NetworkMonitor.isOnline.collectAsState()
+    var typeExpanded by remember { mutableStateOf(false) }
+    var reasonExpanded by remember { mutableStateOf(false) }
+
+    LaunchedEffect(uiState.isSuccess) {
+        if (uiState.isSuccess) onBack()
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxHeight()
+            .padding(20.dp)
+    ) {
+        Spacer(modifier = Modifier.height(30.dp))
+
+        // Encabezado
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Start
+        ) {
+            Button(
+                onClick = onBack,
+                modifier = Modifier.requiredSize(50.dp),
+                shape = CircleShape
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Volver",
+                    modifier = Modifier.requiredSize(25.dp).fillMaxSize()
+                )
+            }
+            Spacer(modifier = Modifier.width(10.dp))
+            Text(
+                text = "Nuevo Reporte",
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.displayMedium,
+                maxLines = 1
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Selector de Tipo
+        Text(text = "Tipo de reporte", style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.height(8.dp))
+        Box {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .clickable { typeExpanded = true },
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = RoundedCornerShape(12.dp),
+                border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline)
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(text = uiState.type, style = MaterialTheme.typography.bodyLarge)
+                    Icon(Icons.Default.ArrowDropDown, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            DropdownMenu(
+                expanded = typeExpanded,
+                onDismissRequest = { typeExpanded = false },
+                modifier = Modifier.fillMaxWidth(0.85f)
+            ) {
+                pqrTypes.forEach { type ->
+                    DropdownMenuItem(
+                        text = { Text(type) },
+                        onClick = {
+                            viewModel.onTypeSelected(type)
+                            typeExpanded = false
+                        }
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Selector de Motivo
+        Text(text = "Motivo del reporte", style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.height(8.dp))
+        Box {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .clickable { reasonExpanded = true },
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = RoundedCornerShape(12.dp),
+                border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline)
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = uiState.selectedReason.ifEmpty { "Selecciona un motivo" },
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = if (uiState.selectedReason.isEmpty())
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        else
+                            MaterialTheme.colorScheme.onSurface
+                    )
+                    Icon(Icons.Default.ArrowDropDown, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            DropdownMenu(
+                expanded = reasonExpanded,
+                onDismissRequest = { reasonExpanded = false },
+                modifier = Modifier.fillMaxWidth(0.85f)
+            ) {
+                pqrReasons.forEach { reason ->
+                    DropdownMenuItem(
+                        text = { Text(reason) },
+                        onClick = {
+                            viewModel.onReasonSelected(reason)
+                            reasonExpanded = false
+                        }
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Descripción
+        Text(text = "Descripción detallada", style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedTextField(
+            value = uiState.description,
+            onValueChange = viewModel::onDescriptionChanged,
+            modifier = Modifier.fillMaxWidth().height(120.dp),
+            placeholder = { Text("Cuéntanos más sobre lo sucedido...") },
+            shape = RoundedCornerShape(12.dp)
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Vincular tutoría
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = "Vincular tutoría previa", style = MaterialTheme.typography.titleMedium)
+            Text(
+                text = "OPCIONAL",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        LazyColumn(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            items(uiState.sessions) { session ->
+                SessionPqrItem(
+                    session = session,
+                    isSelected = uiState.selectedSessionId == session.id,
+                    onClick = { session.id?.let { viewModel.onSessionSelected(it) } }
+                )
+            }
+        }
+
+        // Mensaje de error / conectividad
+        if (!isOnline) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Icon(
+                    Icons.Default.CloudOff,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(16.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "Sin conexión. No es posible enviar el reporte.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = TextAlign.Center
+                )
+            }
+        } else if (uiState.error != null) {
+            Text(
+                text = uiState.error!!,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(vertical = 8.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Botón enviar
+        Button(
+            onClick = viewModel::submitReport,
+            modifier = Modifier.fillMaxWidth().height(56.dp),
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant
+            ),
+            enabled = !uiState.isLoading && isOnline
+        ) {
+            if (uiState.isLoading) {
+                CircularProgressIndicator(
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.size(24.dp)
+                )
+            } else {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = if (isOnline) "Enviar Reporte" else "Sin Conexión",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Icon(
+                        imageVector = if (isOnline) Icons.AutoMirrored.Filled.Send else Icons.Default.CloudOff,
+                        contentDescription = null
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SessionPqrItem(
+    session: SessionDto,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth().clickable { onClick() },
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(12.dp),
+        border = if (isSelected)
+            androidx.compose.foundation.BorderStroke(2.dp, MaterialTheme.colorScheme.primary)
+        else
+            null,
+        tonalElevation = if (isSelected) 4.dp else 1.dp
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (!session.tutor.profileImageUrl.isNullOrBlank()) {
+                AsyncImage(
+                    model = session.tutor.profileImageUrl,
+                    contentDescription = "Foto de ${session.tutor.name}",
+                    modifier = Modifier.size(40.dp).clip(CircleShape),
+                    contentScale = ContentScale.Crop,
+                    error = painterResource(R.drawable.profile_placeholder),
+                    fallback = painterResource(R.drawable.profile_placeholder)
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .background(MaterialTheme.colorScheme.primaryContainer, CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = session.tutor.name.take(1).uppercase(),
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = session.skill.label,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = "Tutor: ${session.tutor.name}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            Icon(
+                imageVector = if (isSelected) Icons.Default.RadioButtonChecked else Icons.Default.RadioButtonUnchecked,
+                contentDescription = null,
+                tint = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrState.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrState.kt
@@ -1,0 +1,24 @@
+package com.uniandes.tutorias_g45k.ui.profile.pages.pqrs
+
+import com.uniandes.tutorias_g45k.data.reservation.SessionDto
+
+data class PqrState(
+    val type: String = "Petición",
+    val selectedReason: String = "",
+    val description: String = "",
+    val sessions: List<SessionDto> = emptyList(),
+    val selectedSessionId: String? = null,
+    val isLoading: Boolean = false,
+    val isSuccess: Boolean = false,
+    val error: String? = null
+)
+
+val pqrTypes = listOf("Petición", "Queja", "Reclamo")
+
+val pqrReasons = listOf(
+    "Problemas con el tutor",
+    "Problemas con el pago",
+    "Problemas técnicos",
+    "Sugerencia",
+    "Otro"
+)

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrViewModel.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrViewModel.kt
@@ -1,0 +1,115 @@
+package com.uniandes.tutorias_g45k.ui.profile.pages.pqrs
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.uniandes.tutorias_g45k.data.auth.AuthHolder
+import com.uniandes.tutorias_g45k.data.local.PqrDraftManager
+import com.uniandes.tutorias_g45k.data.profile.CreatePqrRequest
+import com.uniandes.tutorias_g45k.data.profile.ProfileRepoFirestoreImp
+import com.uniandes.tutorias_g45k.data.profile.ProfileRepository
+import com.uniandes.tutorias_g45k.data.reservation.ReservationRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class PqrViewModel(
+    private val reservationRepository: ReservationRepository = ReservationRepository,
+    private val profileRepository: ProfileRepository = ProfileRepoFirestoreImp,
+    private val draftManager: PqrDraftManager? = null
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PqrState())
+    val uiState: StateFlow<PqrState> = _uiState.asStateFlow()
+
+    init {
+        loadDraft()
+        fetchSessions()
+    }
+
+    private fun loadDraft() {
+        draftManager?.getDraft()?.let { draft ->
+            _uiState.update { it.copy(
+                type = draft.type,
+                selectedReason = draft.selectedReason,
+                description = draft.description,
+                selectedSessionId = draft.selectedSessionId
+            ) }
+        }
+    }
+
+    private fun saveDraft() {
+        val state = _uiState.value
+        draftManager?.saveDraft(
+            type = state.type,
+            selectedReason = state.selectedReason,
+            description = state.description,
+            selectedSessionId = state.selectedSessionId
+        )
+    }
+
+    private fun fetchSessions() {
+        val userId = AuthHolder.authRepo.getCurrentUserId() ?: return
+        viewModelScope.launch {
+            reservationRepository.getUserSessions(userId).collect { sessions ->
+                _uiState.update { it.copy(sessions = sessions) }
+            }
+        }
+    }
+
+    fun onTypeSelected(type: String) {
+        _uiState.update { it.copy(type = type) }
+        saveDraft()
+    }
+
+    fun onReasonSelected(reason: String) {
+        _uiState.update { it.copy(selectedReason = reason) }
+        saveDraft()
+    }
+
+    fun onDescriptionChanged(description: String) {
+        _uiState.update { it.copy(description = description) }
+        saveDraft()
+    }
+
+    fun onSessionSelected(sessionId: String) {
+        _uiState.update { it.copy(selectedSessionId = if (it.selectedSessionId == sessionId) null else sessionId) }
+        saveDraft()
+    }
+
+    fun submitReport() {
+        val currentState = _uiState.value
+        if (currentState.selectedReason.isBlank() || currentState.description.isBlank()) {
+            _uiState.update { it.copy(error = "Por favor completa todos los campos obligatorios") }
+            return
+        }
+
+        val userId = AuthHolder.authRepo.getCurrentUserId() ?: return
+
+        val request = CreatePqrRequest(
+            type = currentState.type,
+            topic = currentState.selectedReason,
+            description = currentState.description,
+            authorId = userId,
+            relatedIncident = currentState.selectedSessionId,
+            status = "Pendiente"
+        )
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            profileRepository.createPqr(request)
+                .onSuccess {
+                    draftManager?.clearDraft()
+                    _uiState.update { it.copy(isLoading = false, isSuccess = true) }
+                }
+                .onFailure { error ->
+                    _uiState.update { it.copy(isLoading = false, error = "Error al enviar el reporte: ${error.message}") }
+                }
+        }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+}

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrViewModelFactory.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/pqrs/PqrViewModelFactory.kt
@@ -1,0 +1,17 @@
+package com.uniandes.tutorias_g45k.ui.profile.pages.pqrs
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.uniandes.tutorias_g45k.data.local.PqrDraftManager
+
+class PqrViewModelFactory(private val context: Context) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(PqrViewModel::class.java)) {
+            val draftManager = PqrDraftManager.getInstance(context)
+            @Suppress("UNCHECKED_CAST")
+            return PqrViewModel(draftManager = draftManager) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/reservations/ReservationListScreen.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/profile/pages/reservations/ReservationListScreen.kt
@@ -159,4 +159,3 @@ fun FilterButton(modifier: Modifier = Modifier, label:String, onClick: () -> Uni
         )
     }
 }
-

--- a/app/src/main/java/com/uniandes/tutorias_g45k/ui/tutor/catalog/TutorViewModel.kt
+++ b/app/src/main/java/com/uniandes/tutorias_g45k/ui/tutor/catalog/TutorViewModel.kt
@@ -219,6 +219,7 @@ class TutorViewModel(
     }
 
     fun onSearchTextChange(text: String) {
+        _uiState.update { it.copy(searchText = text) }
         viewModelScope.launch {
             val state = _uiState.value
             val filtrados = withContext(Dispatchers.Default) {
@@ -226,7 +227,6 @@ class TutorViewModel(
             }
             _uiState.update { currentState ->
                 currentState.copy(
-                    searchText = text,
                     filtrados = filtrados,
                     visibleTutores = filtrados.take(PAGE_SIZE),
                     currentPage = 1


### PR DESCRIPTION
… search cursor fix

- Fix cursor jumping in tutor search bar by updating searchText synchronously before async filter computation
- Fix PQR creation 500 error: restore relatedIncident field now that backend bug (session.student_id → session.student.id) is resolved
- Add image resolution to PQR list: shows other participant's photo when session is linked, author's photo otherwise
- Add temporality and status filters to PQR list screen, mirroring ReservationListScreen pattern
- Fix getUserPqrs query bugs: orderBy and dayRange filter results were silently discarded (Firestore queries are immutable)
- Adapt PQR list and creation form to MaterialTheme, removing all hardcoded dark colors
- Add offline connectivity banner to PQR list screen
- Add tutor profile image to session items in PQR creation form
- Resolve post-pull merge conflicts: preserved local PQR enhancements, kept upstream ReservationListScreen rename and onCheckReviews route